### PR TITLE
check that stringNotEmpty is a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This extension specifies types of values passed to:
 
 * `Assert::integer`
 * `Assert::string`
+* `Assert::stringNotEmpty`
 * `Assert::float`
 * `Assert::numeric`
 * `Assert::boolean`

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -180,6 +180,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						[$value]
 					);
 				},
+				'stringNotEmpty' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('is_string'),
+						[$value]
+					);
+				},
 				'float' => function (Scope $scope, Arg $value): ?\PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_float'),

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -145,6 +145,10 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $ab is: array<PHPStan\Type\WebMozartAssert\Foo>',
 				113,
 			],
+			[
+				'Variable $ac is: string',
+				116,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -7,7 +7,7 @@ use Webmozart\Assert\Assert;
 class Foo
 {
 
-	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab)
+	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, $ac)
 	{
 		$a;
 
@@ -111,6 +111,9 @@ class Foo
 
 		Assert::allSubclassOf($ab, self::class);
 		$ab;
+
+		Assert::stringNotEmpty($ac);
+		$ac;
 	}
 
 }


### PR DESCRIPTION
Check that `Assert::stringNotEmpty($var)` indicate that is `$var` string