### PR TITLE
Fixing the implements interface for string

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -18,6 +18,7 @@ use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -302,8 +303,19 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				},
 				'implementsInterface' => function (Scope $scope, Arg $expr, Arg $class): ?\PhpParser\Node\Expr {
 					$classType = $scope->getType($class->value);
+					$exprType = $scope->getType($expr->value);
 					if (!$classType instanceof ConstantStringType) {
 						return null;
+					}
+
+					if ($exprType instanceof StringType) {
+						return new \PhpParser\Node\Expr\FuncCall(
+							new \PhpParser\Node\Name('in_array'),
+							[
+								$class,
+								new \PhpParser\Node\Expr\FuncCall(new \PhpParser\Node\Name('class_implements'), [$expr]),
+							]
+						);
 					}
 
 					return new \PhpParser\Node\Expr\Instanceof_(

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -313,7 +313,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 							new \PhpParser\Node\Name('in_array'),
 							[
 								$class,
-								new \PhpParser\Node\Expr\FuncCall(new \PhpParser\Node\Name('class_implements'), [$expr]),
+								new \PhpParser\Node\Arg(
+									new \PhpParser\Node\Expr\FuncCall(
+										new \PhpParser\Node\Name('class_implements'),
+										[$expr]
+									)
+								),
 							]
 						);
 					}

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -120,6 +120,8 @@ class Foo
 
         Assert::implementsInterface($ae, Baz::class);
         $ae;
+
+        Assert::implementsInterface(Bar::class, Foo::class);
     }
 
 }


### PR DESCRIPTION
## The problem
The implementation for the `implementsInterface` only works if the first argument is an object If not then it returns `implementsInterface` always returns false according to the plugin. 

## The proposed solution
This is my first attempt in fixing it by adding a `get_class` for the string and see what happens.

The build is currently not working but I know why.