### PR TITLE
Adds support for Assert::classExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This extension specifies types of values passed to:
 * `Assert::same`
 * `Assert::notSame`
 * `Assert::implementsInterface`
+* `Assert::classExists`
 * `nullOr*` and `all*` variants of the above methods
 
 

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -377,6 +377,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						]
 					);
 				},
+				'classExists' => function (Scope $scope, Arg $class): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('class_exists'),
+						[$class]
+					);
+				},
 			];
 		}
 

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -168,6 +168,10 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $things is: array(\'foo\' => string, ?\'bar\' => string)',
 				131,
 			],
+			[
+				'Variable $ag is: class-string',
+				134,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -7,7 +7,7 @@ use Webmozart\Assert\Assert;
 class Foo
 {
 
-	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, $ac, $ad, $ae, $af)
+	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, $ac, $ad, $ae, $af, $ag)
 	{
 		$a;
 
@@ -129,6 +129,9 @@ class Foo
 		$things = doFoo();
 		Assert::keyExists($things, 'foo');
 		$things;
+
+		Assert::classExists($ag);
+		$ag;
     }
 
 }


### PR DESCRIPTION
PHPStan throws errors when `string` is annotated as `@var class-string` even when `Assert::classExists` is used before:

```php
final class Foo
{
   /**
     * @var class-string
     */
   private string $className;

   public __construct(...)
   {
        ....
        Assert::classExists($bar);
        $this->className = $bar;
        // error: Property $className (class-string) does not accept string.  
   }
}
```

This PR adds support for `Assert::classExists` call to help PHPStan understand it.