### PR TITLE
Add support for methodExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This extension specifies types of values passed to:
 * `Assert::notSame`
 * `Assert::implementsInterface`
 * `Assert::classExists`
+* `Assert::methodExists`
 * `nullOr*` and `all*` variants of the above methods
 
 

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -383,6 +383,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						[$class]
 					);
 				},
+				'methodExists' => function (Scope $scope, Arg $value1, Arg $value2): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('method_exists'),
+						[$value1, $value2]
+					);
+				},
 			];
 		}
 

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -132,13 +132,21 @@ class Foo
 
 		Assert::classExists($ag);
 		$ag;
+
+		/** @var object $bar */
+		$bar = new Bar();
+		Assert::methodExists($bar, 'foo');
+		$bar->foo();
     }
 
 }
 
 class Bar
 {
+	public function foo(): void
+	{
 
+	}
 }
 
 interface Baz


### PR DESCRIPTION
This PR adds support for the `Assert::methodExists` method.

~~Tried to implement this (#30) but I now nothing about how PHPStan works internal maybe you can give me a hint what I did wrong.~~

~~Tried to delete my phpstan/cache but it seems not be called any hint?~~