### PR TITLE
Support ::minCount assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This extension specifies types of values passed to:
 * `Assert::notSame`
 * `Assert::implementsInterface`
 * `Assert::classExists`
+* `Assert::minCount`
 * `nullOr*` and `all*` variants of the above methods
 
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.1 || ^8.0",
-		"phpstan/phpstan": "^0.12.40"
+		"phpstan/phpstan": "^0.12.49"
 	},
 	"require-dev": {
 		"phing/phing": "^2.16.3",

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -389,6 +389,15 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						[$class]
 					);
 				},
+				'minCount' => function (Scope $scope, Arg $array, Arg $number): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
+						new \PhpParser\Node\Expr\FuncCall(
+							new \PhpParser\Node\Name('count'),
+							[$array]
+						),
+						$number->value
+					);
+				},
 			];
 		}
 

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -184,6 +184,10 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $ai is: array<string>',
 				146,
 			],
+			[
+				'Variable $ak is: int',
+				152,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -144,6 +144,12 @@ class Foo
 		$ai;
 		Assert::allString($ai);
 		$ai;
+
+		/** @var int[] $aj */
+		$aj = doFoo();
+		Assert::minCount($aj, 1);
+		$ak = array_pop($aj);
+		$ak;
     }
 
 }


### PR DESCRIPTION
Hi,
it would be really great if this extension supports the `::minCount` assertion, in order to write code like this:

```php
/**
 * @param int[] $arr
 * @return int
 */
function foo(array $arr): int
{
  Assert::minCount($arr, 1);
  return array_pop($arr);
}
```