### PR TITLE
Add float type to `integerish` assertion

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -202,21 +202,9 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					);
 				},
 				'integerish' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
-						new \PhpParser\Node\Expr\BinaryOp\BooleanAnd(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('is_string'),
-								[$value]
-							),
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('is_numeric'),
-								[$value]
-							)
-						),
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_int'),
-							[$value]
-						)
+					return new \PhpParser\Node\Expr\FuncCall(
+						new \PhpParser\Node\Name('is_numeric'),
+						[$value]
 					);
 				},
 				'numeric' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -153,7 +153,7 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				116,
 			],
 			[
-				'Variable $ad is: int|(string&numeric)',
+				'Variable $ad is: float|int|(string&numeric)',
 				119,
 			],
 			[


### PR DESCRIPTION
Synching the implementation of the `integerish` assertion with https://github.com/phpstan/phpstan-beberlei-assert as discussed on https://github.com/phpstan/phpstan-beberlei-assert/pull/19