### PR TITLE
Assert::keyExists() implemented failing unit test

### DIFF
--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -188,6 +188,10 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				'Variable $ak is: int',
 				152,
 			],
+			[
+				'Variable $al is: array{key: mixed}',
+				155,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -189,7 +189,7 @@ class AssertTypeSpecifyingExtensionTest extends \PHPStan\Testing\RuleTestCase
 				152,
 			],
 			[
-				'Variable $al is: array{key: mixed}',
+				'Variable $al is: array{foo: mixed, bar: mixed}',
 				155,
 			],
 		]);

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -7,7 +7,7 @@ use Webmozart\Assert\Assert;
 class Foo
 {
 
-	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, $ac, $ad, $ae, $af, $ag, array $ah, $ai)
+	public function doFoo($a, $b, array $c, iterable $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $r, $s, ?int $t, ?int $u, $x, $aa, array $ab, $ac, $ad, $ae, $af, $ag, array $ah, $ai, $al)
 	{
 		$a;
 
@@ -150,6 +150,10 @@ class Foo
 		Assert::minCount($aj, 1);
 		$ak = array_pop($aj);
 		$ak;
+
+		Assert::keyExists($al, 'key');
+		$al;
+
     }
 
 }

--- a/tests/Type/WebMozartAssert/data/data.php
+++ b/tests/Type/WebMozartAssert/data/data.php
@@ -151,7 +151,8 @@ class Foo
 		$ak = array_pop($aj);
 		$ak;
 
-		Assert::keyExists($al, 'key');
+		Assert::keyExists($al, 'foo');
+		Assert::keyExists($al, 'bar');
 		$al;
 
     }


### PR DESCRIPTION
adds failing test for https://github.com/phpstan/phpstan-webmozart-assert/issues/39

it seems there [is already some kind of `keyExists` handling](https://github.com/phpstan/phpstan-webmozart-assert/blob/1657403194a43f83b5355bd400aa7fc63f0e6857/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php#L317-L322), but it does not work yet for the added testcase

