### PR TITLE
Support positiveInteger

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ function demo(?int $a) {
 This extension specifies types of values passed to:
 
 * `Assert::integer`
+* `Assert::positiveInteger`
 * `Assert::string`
 * `Assert::stringNotEmpty`
 * `Assert::float`

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpstan/phpstan-strict-rules": "^1.0",
 		"phpunit/phpunit": "^9.5",
-		"webmozart/assert": "^1.9.1"
+		"webmozart/assert": "^1.10.0"
 	},
 	"config": {
 		"platform": {

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -177,6 +177,18 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						[$value]
 					);
 				},
+				'positiveInteger' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
+					return new \PhpParser\Node\Expr\BinaryOp\BooleanAnd(
+						new \PhpParser\Node\Expr\FuncCall(
+							new \PhpParser\Node\Name('is_int'),
+							[$value]
+						),
+						new \PhpParser\Node\Expr\BinaryOp\Greater(
+							$value->value,
+							new \PhpParser\Node\Scalar\LNumber(0)
+						)
+					);
+				},
 				'string' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_string'),

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -16,6 +16,7 @@ class AssertTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/collection.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/data.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/string.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/type.php');
 	}
 
 	/**

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\WebMozartAssert;
+
+use Webmozart\Assert\Assert;
+
+class TypeTest
+{
+	/**
+	 * @param mixed $a
+	 */
+	public function positiveInteger($a): void
+	{
+		Assert::positiveInteger($a);
+		\PHPStan\Testing\assertType('int<1, max>', $a);
+
+		$b = -1;
+		Assert::positiveInteger($b);
+		\PHPStan\Testing\assertType('*NEVER*', $b);
+	}
+}


### PR DESCRIPTION
Is this fine like that or basically too early as it is a kind of pseudo type as non-empty-(array|list) is?
I'd say this is better than not narrowing the type at all :)