### PR TITLE
Support string assertions resulting in non-empty-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,22 @@ This extension specifies types of values passed to:
 * `Assert::methodExists`
 * `Assert::propertyExists`
 * `Assert::isArrayAccessible`
+* `Assert::unicodeLetters`
+* `Assert::alpha`
+* `Assert::digits`
+* `Assert::alnum`
+* `Assert::lower`
+* `Assert::upper`
 * `Assert::length`
 * `Assert::minLength`
 * `Assert::maxLength`
 * `Assert::lengthBetween`
+* `Assert::uuid`
+* `Assert::ip`
+* `Assert::ipv4`
+* `Assert::ipv6`
+* `Assert::email`
+* `Assert::notWhitespaceOnly`
 * `nullOr*` and `all*` variants of the above methods
 
 

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -28,6 +28,22 @@ use PHPStan\Type\TypeUtils;
 class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
+	private const ASSERTIONS_RESULTING_IN_NON_EMPTY_STRING = [
+		'stringNotEmpty',
+		'unicodeLetters',
+		'alpha',
+		'digits',
+		'alnum',
+		'lower',
+		'upper',
+		'uuid',
+		'ip',
+		'ipv4',
+		'ipv6',
+		'email',
+		'notWhitespaceOnly',
+	];
+
 	/** @var \Closure[] */
 	private static $resolvers;
 
@@ -50,6 +66,10 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 		TypeSpecifierContext $context
 	): bool
 	{
+		if (in_array($staticMethodReflection->getName(), self::ASSERTIONS_RESULTING_IN_NON_EMPTY_STRING, true)) {
+			return true;
+		}
+
 		if (substr($staticMethodReflection->getName(), 0, 6) === 'allNot') {
 			$methods = [
 				'allNotInstanceOf' => 2,
@@ -144,6 +164,11 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 	): ?\PhpParser\Node\Expr
 	{
 		$trimmedName = self::trimName($name);
+
+		if (in_array($trimmedName, self::ASSERTIONS_RESULTING_IN_NON_EMPTY_STRING, true)) {
+			return self::createIsNonEmptyStringExpression($args);
+		}
+
 		$resolvers = self::getExpressionResolvers();
 		$resolver = $resolvers[$trimmedName];
 		$expression = $resolver($scope, ...$args);
@@ -193,18 +218,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					return new \PhpParser\Node\Expr\FuncCall(
 						new \PhpParser\Node\Name('is_string'),
 						[$value]
-					);
-				},
-				'stringNotEmpty' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
-							[$value]
-						),
-						new NotIdentical(
-							$value->value,
-							new String_('')
-						)
 					);
 				},
 				'float' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
@@ -671,6 +684,23 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			$expr,
 			$specifiedType,
 			TypeSpecifierContext::createTruthy()
+		);
+	}
+
+	/**
+	 * @param \PhpParser\Node\Arg[] $args
+	 */
+	private static function createIsNonEmptyStringExpression(array $args): \PhpParser\Node\Expr
+	{
+		return new BooleanAnd(
+			new \PhpParser\Node\Expr\FuncCall(
+				new \PhpParser\Node\Name('is_string'),
+				[$args[0]]
+			),
+			new NotIdentical(
+				$args[0]->value,
+				new String_('')
+			)
 		);
 	}
 

--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -49,4 +49,76 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string', $d);
 	}
 
+	public function unicodeLetters($a): void
+	{
+		Assert::unicodeLetters($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function alpha($a): void
+	{
+		Assert::alpha($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function digits(string $a): void
+	{
+		Assert::digits($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function alnum(string $a): void
+	{
+		Assert::alnum($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function lower(string $a): void
+	{
+		Assert::lower($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function upper(string $a): void
+	{
+		Assert::upper($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function uuid(string $a): void
+	{
+		Assert::uuid($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ip($a): void
+	{
+		Assert::ip($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ipv4($a): void
+	{
+		Assert::ipv4($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ipv6($a): void
+	{
+		Assert::ipv6($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function email($a): void
+	{
+		Assert::email($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function notWhitespaceOnly(string $a): void
+	{
+		Assert::notWhitespaceOnly($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
 }


### PR DESCRIPTION
Not sure if this is the best solution tbh., let me know if you have any other ideas.

A few string assertions are still left like e.g. `contains` or `startsWith` but they should have dedicated resolvers IMO to check if the needle is a non-empty-string or not. I'd look at them in a dedicated PR afterwards.