### PR TITLE
Rework non-empty-string assertions

### DIFF
--- a/tests/Type/WebMozartAssert/data/array.php
+++ b/tests/Type/WebMozartAssert/data/array.php
@@ -25,13 +25,16 @@ class ArrayTest
 		\PHPStan\Testing\assertType('array{foo: string, bar?: string}', $a);
 	}
 
-	public function validArrayKey($a, bool $b): void
+	public function validArrayKey($a, bool $b, $c): void
 	{
 		Assert::validArrayKey($a);
 		\PHPStan\Testing\assertType('int|string', $a);
 
 		Assert::validArrayKey($b);
 		\PHPStan\Testing\assertType('*NEVER*', $b);
+
+		Assert::nullOrValidArrayKey($c);
+		\PHPStan\Testing\assertType('int|string|null', $c);
 	}
 
 	/**
@@ -94,10 +97,13 @@ class ArrayTest
 		\PHPStan\Testing\assertType('*NEVER*', $d);
 	}
 
-	public function isList($a): void
+	public function isList($a, $b): void
 	{
 		Assert::isList($a);
 		\PHPStan\Testing\assertType('array', $a);
+
+		Assert::nullOrIsList($b);
+		\PHPStan\Testing\assertType('array|null', $b);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -13,6 +13,12 @@ class CollectionTest
 		\PHPStan\Testing\assertType('array<string>', $a);
 	}
 
+	public function allStringNotEmpty(array $a): void
+	{
+		Assert::allStringNotEmpty($a);
+		\PHPStan\Testing\assertType('array<non-empty-string>', $a);
+	}
+
 	public function allInteger(array $a, iterable $b, iterable $c): void
 	{
 		Assert::allInteger($a);
@@ -53,6 +59,12 @@ class CollectionTest
 	{
 		Assert::allNotSame($a, -1);
 		\PHPStan\Testing\assertType('array{1, -2|2, -3|3}', $a);
+	}
+
+	public function allEmail(array $a): void
+	{
+		Assert::allEmail($a);
+		\PHPStan\Testing\assertType('array<non-empty-string>', $a);
 	}
 
 	public function allSubclassOf(array $a, $b): void

--- a/tests/Type/WebMozartAssert/data/comparison.php
+++ b/tests/Type/WebMozartAssert/data/comparison.php
@@ -6,19 +6,25 @@ use Webmozart\Assert\Assert;
 
 class ComparisonTest
 {
-	public function true($a): void
+	public function true($a, $b): void
 	{
 		Assert::true($a);
 		\PHPStan\Testing\assertType('true', $a);
+
+		Assert::nullOrTrue($b);
+		\PHPStan\Testing\assertType('true|null', $b);
 	}
 
-	public function false($a): void
+	public function false($a, $b): void
 	{
 		Assert::false($a);
 		\PHPStan\Testing\assertType('false', $a);
+
+		Assert::nullOrFalse($b);
+		\PHPStan\Testing\assertType('false|null', $b);
 	}
 
-	public function notFalse(int $a): void
+	public function notFalse($a, $b): void
 	{
 		/** @var int|false $a */
 		Assert::notFalse($a);
@@ -37,10 +43,13 @@ class ComparisonTest
 		\PHPStan\Testing\assertType('int', $a);
 	}
 
-	public function same($a): void
+	public function same($a, $b): void
 	{
 		Assert::same($a, 1);
 		\PHPStan\Testing\assertType('1', $a);
+
+		Assert::nullOrSame($b, 1);
+		\PHPStan\Testing\assertType('1|null', $b);
 	}
 
 	/**
@@ -61,9 +70,12 @@ class ComparisonTest
 		\PHPStan\Testing\assertType('\'bar\'|\'foo\'|null', $b);
 	}
 
-	public function oneOf($a): void
+	public function oneOf($a, $b): void
 	{
 		Assert::oneOf($a, [1, 2]);
 		\PHPStan\Testing\assertType('1|2', $a);
+
+		Assert::nullOrOneOf($b, [1, 2]);
+		\PHPStan\Testing\assertType('1|2|null', $b);
 	}
 }

--- a/tests/Type/WebMozartAssert/data/object.php
+++ b/tests/Type/WebMozartAssert/data/object.php
@@ -7,28 +7,40 @@ use Webmozart\Assert\Assert;
 class ObjectTest
 {
 
-	public function classExists($a): void
+	public function classExists($a, $b): void
 	{
 		Assert::classExists($a);
 		\PHPStan\Testing\assertType('class-string', $a);
+
+		Assert::nullOrClassExists($b);
+		\PHPStan\Testing\assertType('class-string|null', $b);
 	}
 
-	public function subclassOf($a): void
+	public function subclassOf($a, $b): void
 	{
 		Assert::subclassOf($a, self::class);
 		\PHPStan\Testing\assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest', $a);
+
+		Assert::nullOrSubclassOf($b, self::class);
+		\PHPStan\Testing\assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest|null', $b);
 	}
 
-	public function interfaceExists($a): void
+	public function interfaceExists($a, $b): void
 	{
 		Assert::interfaceExists($a);
 		\PHPStan\Testing\assertType('class-string', $a);
+
+		Assert::nullOrInterfaceExists($b);
+		\PHPStan\Testing\assertType('class-string|null', $b);
 	}
 
-	public function implementsInterface($a): void
+	public function implementsInterface($a, $b): void
 	{
 		Assert::implementsInterface($a, ObjectFoo::class);
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\ObjectFoo', $a);
+
+		Assert::nullOrImplementsInterface($b, ObjectFoo::class);
+		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\ObjectFoo|null', $b);
 	}
 
 	public function propertyExists(object $a): void

--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -10,73 +10,97 @@ class TestStrings
 	/**
 	 * @param non-empty-string $b
 	 */
-	public function contains(string $a, string $b): void
+	public function contains(string $a, string $b, string $c, $d): void
 	{
 		Assert::contains($a, $a);
 		\PHPStan\Testing\assertType('string', $a);
 
 		Assert::contains($a, $b);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrContains($c, $b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $c);
+
+		Assert::contains($d, $b);
+		\PHPStan\Testing\assertType('mixed', $d); // not further narrowed down because the assertion expects a string
 	}
 
 	/**
 	 * @param non-empty-string $b
 	 */
-	public function startsWith(string $a, string $b): void
+	public function startsWith(string $a, string $b, string $c): void
 	{
 		Assert::startsWith($a, $a);
 		\PHPStan\Testing\assertType('string', $a);
 
 		Assert::startsWith($a, $b);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrStartsWith($c, $b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $c);
 	}
 
-	public function startsWithLetter(string $a): void
+	public function startsWithLetter(string $a, string $b): void
 	{
 		Assert::startsWithLetter($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrStartsWithLetter($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
 	/**
 	 * @param non-empty-string $b
 	 */
-	public function endsWith(string $a, string $b): void
+	public function endsWith(string $a, string $b, string $c): void
 	{
 		Assert::endsWith($a, $a);
 		\PHPStan\Testing\assertType('string', $a);
 
 		Assert::endsWith($a, $b);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrEndsWith($c, $b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $c);
 	}
 
-	public function length(string $a, string $b): void
+	public function length(string $a, string $b, string $c): void
 	{
 		Assert::length($a, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
 
 		Assert::length($b, 1);
 		\PHPStan\Testing\assertType('non-empty-string', $b);
+
+		Assert::nullOrLength($c, 1);
+		\PHPStan\Testing\assertType('non-empty-string|null', $c);
 	}
 
-	public function minLength(string $a, string $b): void
+	public function minLength(string $a, string $b, string $c): void
 	{
 		Assert::minLength($a, 0);
 		\PHPStan\Testing\assertType('string', $a);
 
 		Assert::minLength($b, 1);
 		\PHPStan\Testing\assertType('non-empty-string', $b);
+
+		Assert::nullOrMinLength($c, 1);
+		\PHPStan\Testing\assertType('non-empty-string|null', $c);
 	}
 
-	public function maxLength(string $a, string $b): void
+	public function maxLength(string $a, string $b, string $c): void
 	{
 		Assert::maxLength($a, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
 
 		Assert::maxLength($b, 1);
 		\PHPStan\Testing\assertType('string', $b);
+
+		Assert::nullOrMaxLength($c, 1);
+		\PHPStan\Testing\assertType('string|null', $c);
 	}
 
-	public function lengthBetween(string $a, string $b, string $c, string $d): void
+	public function lengthBetween(string $a, string $b, string $c, string $d, string $e): void
 	{
 		Assert::lengthBetween($a, 0, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
@@ -89,18 +113,27 @@ class TestStrings
 
 		Assert::lengthBetween($d, 1, 1);
 		\PHPStan\Testing\assertType('non-empty-string', $d);
+
+		Assert::nullOrLengthBetween($e, 1, 1);
+		\PHPStan\Testing\assertType('non-empty-string|null', $e);
 	}
 
-	public function unicodeLetters($a): void
+	public function unicodeLetters($a, $b): void
 	{
 		Assert::unicodeLetters($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrUnicodeLetters($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function alpha($a): void
+	public function alpha($a, $b): void
 	{
 		Assert::alpha($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrAlpha($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
 	public function digits(string $a): void
@@ -127,40 +160,61 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string', $a);
 	}
 
-	public function uuid(string $a): void
+	public function uuid(string $a, string $b): void
 	{
 		Assert::uuid($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrUuid($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function ip($a): void
+	public function ip($a, $b): void
 	{
 		Assert::ip($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrIp($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function ipv4($a): void
+	public function ipv4($a, $b): void
 	{
 		Assert::ipv4($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrIpv4($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function ipv6($a): void
+	public function ipv6($a, $b): void
 	{
 		Assert::ipv6($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrIpv6($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function email($a): void
+	public function email($a, $b): void
 	{
 		Assert::email($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrEmail($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
-	public function notWhitespaceOnly(string $a): void
+	public function notWhitespaceOnly(string $a, string $b, $c): void
 	{
 		Assert::notWhitespaceOnly($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrNotWhitespaceOnly($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
+
+		Assert::notWhitespaceOnly($c);
+		\PHPStan\Testing\assertType('mixed', $c); // not further narrowed down because the assertion expects a string
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -6,16 +6,22 @@ use Webmozart\Assert\Assert;
 
 class TypeTest
 {
-	public function string($a): void
+	public function string($a, $b): void
 	{
 		Assert::string($a);
 		\PHPStan\Testing\assertType('string', $a);
+
+		Assert::nullOrString($b);
+		\PHPStan\Testing\assertType('string|null', $b);
 	}
 
-	public function stringNotEmpty($a): void
+	public function stringNotEmpty($a, $b): void
 	{
 		Assert::stringNotEmpty($a);
 		\PHPStan\Testing\assertType('non-empty-string', $a);
+
+		Assert::nullOrStringNotEmpty($b);
+		\PHPStan\Testing\assertType('non-empty-string|null', $b);
 	}
 
 	public function integer($a, $b): void
@@ -27,96 +33,138 @@ class TypeTest
 		\PHPStan\Testing\assertType('int|null', $b);
 	}
 
-	public function integerish($a): void
+	public function integerish($a, $b): void
 	{
 		Assert::integerish($a);
 		\PHPStan\Testing\assertType('float|int|numeric-string', $a);
+
+		Assert::nullOrIntegerish($b);
+		\PHPStan\Testing\assertType('float|int|numeric-string|null', $b);
 	}
 
-	public function positiveInteger($a): void
+	public function positiveInteger($a, $b, $c): void
 	{
 		Assert::positiveInteger($a);
 		\PHPStan\Testing\assertType('int<1, max>', $a);
 
-		$b = -1;
+		/** @var -1 $b */
 		Assert::positiveInteger($b);
 		\PHPStan\Testing\assertType('*NEVER*', $b);
+
+		Assert::nullOrPositiveInteger($c);
+		\PHPStan\Testing\assertType('int<1, max>|null', $c);
 	}
 
-	public function float($a): void
+	public function float($a, $b): void
 	{
 		Assert::float($a);
 		\PHPStan\Testing\assertType('float', $a);
+
+		Assert::nullOrFloat($b);
+		\PHPStan\Testing\assertType('float|null', $b);
 	}
 
-	public function numeric($a): void
+	public function numeric($a, $b): void
 	{
 		Assert::numeric($a);
 		\PHPStan\Testing\assertType('float|int|numeric-string', $a);
+
+		Assert::nullOrNumeric($b);
+		\PHPStan\Testing\assertType('float|int|numeric-string|null', $b);
 	}
 
-	public function natural($a): void
+	public function natural($a, $b, $c): void
 	{
 		Assert::natural($a);
 		\PHPStan\Testing\assertType('int<0, max>', $a);
 
-		$b = -1;
+		/** @var -1 $b */
 		Assert::natural($b);
 		\PHPStan\Testing\assertType('*NEVER*', $b);
+
+		Assert::nullOrNatural($c);
+		\PHPStan\Testing\assertType('int<0, max>|null', $c);
 	}
 
-	public function boolean($a): void
+	public function boolean($a, $b): void
 	{
 		Assert::boolean($a);
 		\PHPStan\Testing\assertType('bool', $a);
+
+		Assert::nullOrBoolean($b);
+		\PHPStan\Testing\assertType('bool|null', $b);
 	}
 
-	public function scalar($a): void
+	public function scalar($a, $b): void
 	{
 		Assert::scalar($a);
 		\PHPStan\Testing\assertType('bool|float|int|string', $a);
+
+		Assert::nullOrScalar($b);
+		\PHPStan\Testing\assertType('bool|float|int|string|null', $b);
 	}
 
-	public function object($a): void
+	public function object($a, $b): void
 	{
 		Assert::object($a);
 		\PHPStan\Testing\assertType('object', $a);
+
+		Assert::nullOrObject($b);
+		\PHPStan\Testing\assertType('object|null', $b);
 	}
 
-	public function resource($a): void
+	public function resource($a, $b): void
 	{
 		Assert::resource($a);
 		\PHPStan\Testing\assertType('resource', $a);
+
+		Assert::nullOrResource($b);
+		\PHPStan\Testing\assertType('resource|null', $b);
 	}
 
-	public function isCallable($a): void
+	public function isCallable($a, $b): void
 	{
 		Assert::isCallable($a);
 		\PHPStan\Testing\assertType('callable(): mixed', $a);
+
+		Assert::nullOrIsCallable($b);
+		\PHPStan\Testing\assertType('(callable(): mixed)|null', $b);
 	}
 
-	public function isArray($a): void
+	public function isArray($a, $b): void
 	{
 		Assert::isArray($a);
 		\PHPStan\Testing\assertType('array', $a);
+
+		Assert::nullOrIsArray($b);
+		\PHPStan\Testing\assertType('array|null', $b);
 	}
 
-	public function isIterable($a): void
+	public function isIterable($a, $b): void
 	{
 		Assert::isIterable($a);
 		\PHPStan\Testing\assertType('array|Traversable', $a);
+
+		Assert::nullOrIsIterable($b);
+		\PHPStan\Testing\assertType('array|Traversable|null', $b);
 	}
 
-	public function isCountable($a): void
+	public function isCountable($a, $b): void
 	{
 		Assert::isCountable($a);
 		\PHPStan\Testing\assertType('array|Countable', $a);
+
+		Assert::nullOrIsCountable($b);
+		\PHPStan\Testing\assertType('array|Countable|null', $b);
 	}
 
-	public function isInstanceOf($a): void
+	public function isInstanceOf($a, $b): void
 	{
 		Assert::isInstanceOf($a, self::class);
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest', $a);
+
+		Assert::nullOrIsInstanceOf($b, self::class);
+		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest|null', $b);
 	}
 
 	/**
@@ -128,9 +176,12 @@ class TypeTest
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Foo', $a);
 	}
 
-	public function isArrayAccessible($a): void
+	public function isArrayAccessible($a, $b): void
 	{
 		Assert::isArrayAccessible($a);
 		\PHPStan\Testing\assertType('array|ArrayAccess', $a);
+
+		Assert::nullOrIsArrayAccessible($b);
+		\PHPStan\Testing\assertType('array|ArrayAccess|null', $b);
 	}
 }

--- a/tests/WebMozartIntegration/PHPStanIntegrationTest.php
+++ b/tests/WebMozartIntegration/PHPStanIntegrationTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\WebMozartIntegration;
+
+use PHPStan\Testing\LevelsTestCase;
+
+final class PHPStanIntegrationTest extends LevelsTestCase
+{
+
+	public function dataTopics(): array
+	{
+		return [
+			['bug-33'],
+			['bug-85'],
+		];
+	}
+
+	public function getDataPath(): string
+	{
+		return __DIR__ . '/data';
+	}
+
+	public function getPhpStanExecutablePath(): string
+	{
+		return __DIR__ . '/../../vendor/phpstan/phpstan/phpstan';
+	}
+
+	public function getPhpStanConfigPath(): string
+	{
+		return __DIR__ . '/phpstan.neon';
+	}
+
+}

--- a/tests/WebMozartIntegration/data/bug-33.php
+++ b/tests/WebMozartIntegration/data/bug-33.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStan\WebMozartIntegration\Bug33;
+
+use Webmozart\Assert\Assert;
+
+final class Bug33
+{
+
+	public function foo(?string $bar): void
+	{
+		Assert::nullOrStringNotEmpty($bar);
+		\PHPStan\Testing\assertType('non-empty-string|null', $bar);
+	}
+
+}

--- a/tests/WebMozartIntegration/data/bug-85.php
+++ b/tests/WebMozartIntegration/data/bug-85.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStan\WebMozartIntegration\Bug85;
+
+use Webmozart\Assert\Assert;
+
+final class Bug85
+{
+
+	public function foo(string $cityCode): void
+	{
+		Assert::length($cityCode, 3);
+		Assert::upper($cityCode);
+
+		\PHPStan\Testing\assertType('non-empty-string', $cityCode);
+	}
+
+	/**
+	 * @param mixed $url
+	 */
+	function bar($url): void
+	{
+		Assert::stringNotEmpty($url);
+		Assert::contains($url, '/');
+		Assert::startsWith($url, 'https://github.com/');
+
+		\PHPStan\Testing\assertType('non-empty-string', $url);
+	}
+
+}

--- a/tests/WebMozartIntegration/phpstan.neon
+++ b/tests/WebMozartIntegration/phpstan.neon
@@ -1,0 +1,4 @@
+includes:
+	- ../../extension.neon
+	- ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+	- ../../vendor/phpstan/phpstan/conf/bleedingEdge.neon


### PR DESCRIPTION
This does a couple of things
- Removes the hacky non-empty-string expression re-usage and replaces it with type specifying and calls to `$this->typeSpecifier->create` (I hope this closes #85)
- Removes the expression adaption for `nullOr*` assertions and replaces it with `TypeCombinator::addNull` and calls to `$this->typeSpecifier->create`. This should close #33.
- Tries to detect the type from `SpecifiedTypes` a bit smarter by also looking at the `sureNotTypes`. This retains `non-empty-string` via `nullOr*` and `all*` better
- Adds integration and many other tests, e.g. some cases of `all*` and  `nullOr*` almost everywhere, where it makes sense
- Fixes some of the non-empty-string resulting assertions that expect a string as argument (e.g. `contains` or `notWhitespaceOnly`)

I know this is a big one, I'm happy to split it up or whatever makes sense. Some of the non-empty-string things seem to be a bit intertwined though.