### PR TITLE
Update Slevomat CS to ^7.0

### DIFF
--- a/build-cs/composer.json
+++ b/build-cs/composer.json
@@ -2,7 +2,7 @@
 	"require-dev": {
 		"consistence-community/coding-standard": "^3.10",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"slevomat/coding-standard": "^6.4"
+		"slevomat/coding-standard": "^7.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="PHPStan webmozart/assert extension">
+	<config name="php_version" value="70100"/>
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="utf-8"/>
@@ -8,59 +9,102 @@
 	<arg value="sp"/>
 	<file>src</file>
 	<file>tests</file>
+
 	<rule ref="build-cs/vendor/consistence-community/coding-standard/Consistence/ruleset.xml">
-		<exclude name="Squiz.Functions.GlobalFunction.Found"/>
-		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
+		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
+		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
-		<exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
+		<exclude name="Consistence.Exceptions.ExceptionDeclaration"/>
+		<exclude name="Squiz.Commenting.FunctionComment"/>
+		<exclude name="Squiz.PHP.Heredoc.NotAllowed"/>
+		<exclude name="Squiz.WhiteSpace.FunctionSpacing.Before"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
 		<properties>
 			<property name="caseSensitive" value="false"/>
+			<property name="psr12Compatible" value="true"/>
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<properties>
-			<property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
+			<property name="declareOnFirstLine" value="true"/>
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-		<properties>
-			<property name="usefulAnnotations" type="array" value="
-				@dataProvider,
-				@requires
-			"/>
-			<property name="enableObjectTypeHint" value="false"/>
-		</properties>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation">
+		<severity>10</severity>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-		<properties>
-			<property name="enableNativeTypeHint" value="false"/>
-		</properties>
 		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
 	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-		<properties>
-			<property name="enableObjectTypeHint" value="false"/>
-		</properties>
-		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation">
+		<severity>10</severity>
 	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation">
+		<severity>10</severity>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure.UnusedInheritedVariable"/>
+	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
-	<rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+		<exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElseIf"/>
+	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
-	<!-- <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>-->
-	<!-- <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/> -->
-	<!-- <rule ref="SlevomatCodingStandard.PHP.ShortList"/> -->
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>
-			<property name="rootNamespaces" type="array" value="src=>PHPStan,tests=>PHPStan"/>
+			<property name="rootNamespaces" type="array">
+				<element key="src" value="PHPStan"/>
+				<element key="tests" value="PHPStan"/>
+			</property>
+
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+	<rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+	<rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+	<!--<rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>-->
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+		<properties>
+			<property name="searchAnnotations" value="true"/>
+			<property name="namespacesRequiredToUse" value=""/>
+			<property name="allowPartialUses" value="true"/>
+			<property name="allowFallbackGlobalFunctions" value="false"/>
+			<property name="allowFallbackGlobalConstants" value="false"/>
+			<property name="allowFullyQualifiedExceptions" value="false"/>
+			<property name="allowFullyQualifiedNameForCollidingClasses" value="true"/>
+			<property name="allowFullyQualifiedNameForCollidingFunctions" value="true"/>
+			<property name="allowFullyQualifiedNameForCollidingConstants" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
+	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<properties>
+			<property name="spacing" value="1" />
+			<property name="spacingBeforeFirst" value="1"/>
+			<property name="spacingAfterLast" value="1"/>
+		</properties>
+	</rule>
+	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+	<rule ref="Consistence.NamingConventions.ValidVariableName.NotCamelCaps"/>
 	<exclude-pattern>tests/tmp</exclude-pattern>
 	<exclude-pattern>tests/*/data</exclude-pattern>
 </ruleset>

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -2,10 +2,25 @@
 
 namespace PHPStan\Type\WebMozartAssert;
 
+use ArrayAccess;
+use Closure;
+use Countable;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\Greater;
+use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
+use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
@@ -13,6 +28,7 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
@@ -24,14 +40,22 @@ use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
+use ReflectionObject;
+use Traversable;
+use function array_key_exists;
+use function count;
+use function key;
+use function lcfirst;
+use function reset;
+use function substr;
 
 class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
 
-	/** @var \Closure[] */
+	/** @var Closure[] */
 	private static $resolvers;
 
-	/** @var \PHPStan\Analyser\TypeSpecifier */
+	/** @var TypeSpecifier */
 	private $typeSpecifier;
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
@@ -68,9 +92,9 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 		}
 
 		$resolver = $resolvers[$trimmedName];
-		$resolverReflection = new \ReflectionObject($resolver);
+		$resolverReflection = new ReflectionObject($resolver);
 
-		return count($node->getArgs()) >= (count($resolverReflection->getMethod('__invoke')->getParameters()) - 1);
+		return count($node->getArgs()) >= count($resolverReflection->getMethod('__invoke')->getParameters()) - 1;
 	}
 
 	private static function trimName(string $name): string
@@ -118,13 +142,13 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				return $this->arrayOrIterable(
 					$scope,
 					$sureType[0],
-					function () use ($sureType): Type {
+					static function () use ($sureType): Type {
 						return $sureType[1];
 					}
 				);
 			}
 			if (count($specifiedTypes->getSureNotTypes()) > 0) {
-				throw new \PHPStan\ShouldNotHappenException();
+				throw new ShouldNotHappenException();
 			}
 		}
 
@@ -132,16 +156,13 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 	}
 
 	/**
-	 * @param Scope $scope
-	 * @param string $name
-	 * @param \PhpParser\Node\Arg[] $args
-	 * @return \PhpParser\Node\Expr|null
+	 * @param Arg[] $args
 	 */
 	private static function createExpression(
 		Scope $scope,
 		string $name,
 		array $args
-	): ?\PhpParser\Node\Expr
+	): ?Expr
 	{
 		$trimmedName = self::trimName($name);
 		$resolvers = self::getExpressionResolvers();
@@ -152,11 +173,11 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 		}
 
 		if (substr($name, 0, 6) === 'nullOr') {
-			$expression = new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
+			$expression = new BooleanOr(
 				$expression,
-				new \PhpParser\Node\Expr\BinaryOp\Identical(
+				new Identical(
 					$args[0]->value,
-					new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('null'))
+					new ConstFetch(new Name('null'))
 				)
 			);
 		}
@@ -165,40 +186,40 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 	}
 
 	/**
-	 * @return \Closure[]
+	 * @return Closure[]
 	 */
 	private static function getExpressionResolvers(): array
 	{
 		if (self::$resolvers === null) {
 			self::$resolvers = [
-				'integer' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_int'),
+				'integer' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_int'),
 						[$value]
 					);
 				},
-				'positiveInteger' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_int'),
+				'positiveInteger' => static function (Scope $scope, Arg $value): Expr {
+					return new BooleanAnd(
+						new FuncCall(
+							new Name('is_int'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\BinaryOp\Greater(
+						new Greater(
 							$value->value,
-							new \PhpParser\Node\Scalar\LNumber(0)
+							new LNumber(0)
 						)
 					);
 				},
-				'string' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_string'),
+				'string' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_string'),
 						[$value]
 					);
 				},
-				'stringNotEmpty' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
+				'stringNotEmpty' => static function (Scope $scope, Arg $value): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						),
 						new NotIdentical(
@@ -207,333 +228,333 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						)
 					);
 				},
-				'float' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_float'),
+				'float' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_float'),
 						[$value]
 					);
 				},
-				'integerish' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_numeric'),
+				'integerish' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_numeric'),
 						[$value]
 					);
 				},
-				'numeric' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_numeric'),
+				'numeric' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_numeric'),
 						[$value]
 					);
 				},
-				'natural' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_int'),
+				'natural' => static function (Scope $scope, Arg $value): Expr {
+					return new BooleanAnd(
+						new FuncCall(
+							new Name('is_int'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
+						new GreaterOrEqual(
 							$value->value,
-							new \PhpParser\Node\Scalar\LNumber(0)
+							new LNumber(0)
 						)
 					);
 				},
-				'boolean' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_bool'),
+				'boolean' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_bool'),
 						[$value]
 					);
 				},
-				'scalar' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_scalar'),
+				'scalar' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_scalar'),
 						[$value]
 					);
 				},
-				'object' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_object'),
+				'object' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_object'),
 						[$value]
 					);
 				},
-				'resource' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_resource'),
+				'resource' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_resource'),
 						[$value]
 					);
 				},
-				'isCallable' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_callable'),
+				'isCallable' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_callable'),
 						[$value]
 					);
 				},
-				'isArray' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_array'),
+				'isArray' => static function (Scope $scope, Arg $value): Expr {
+					return new FuncCall(
+						new Name('is_array'),
 						[$value]
 					);
 				},
-				'isIterable' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_array'),
+				'isIterable' => static function (Scope $scope, Arg $expr): Expr {
+					return new BooleanOr(
+						new FuncCall(
+							new Name('is_array'),
 							[$expr]
 						),
-						new \PhpParser\Node\Expr\Instanceof_(
+						new Instanceof_(
 							$expr->value,
-							new \PhpParser\Node\Name(\Traversable::class)
+							new Name(Traversable::class)
 						)
 					);
 				},
-				'isList' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_array'),
+				'isList' => static function (Scope $scope, Arg $expr): Expr {
+					return new FuncCall(
+						new Name('is_array'),
 						[$expr]
 					);
 				},
-				'isCountable' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_array'),
+				'isCountable' => static function (Scope $scope, Arg $expr): Expr {
+					return new BooleanOr(
+						new FuncCall(
+							new Name('is_array'),
 							[$expr]
 						),
-						new \PhpParser\Node\Expr\Instanceof_(
+						new Instanceof_(
 							$expr->value,
-							new \PhpParser\Node\Name(\Countable::class)
+							new Name(Countable::class)
 						)
 					);
 				},
-				'isInstanceOf' => function (Scope $scope, Arg $expr, Arg $class): ?\PhpParser\Node\Expr {
+				'isInstanceOf' => static function (Scope $scope, Arg $expr, Arg $class): ?Expr {
 					$classType = $scope->getType($class->value);
 					if (!$classType instanceof ConstantStringType) {
 						return null;
 					}
 
-					return new \PhpParser\Node\Expr\Instanceof_(
+					return new Instanceof_(
 						$expr->value,
-						new \PhpParser\Node\Name($classType->getValue())
+						new Name($classType->getValue())
 					);
 				},
-				'notInstanceOf' => function (Scope $scope, Arg $expr, Arg $class): ?\PhpParser\Node\Expr {
+				'notInstanceOf' => static function (Scope $scope, Arg $expr, Arg $class): ?Expr {
 					$classType = $scope->getType($class->value);
 					if (!$classType instanceof ConstantStringType) {
 						return null;
 					}
 
-					return new \PhpParser\Node\Expr\BooleanNot(
-						new \PhpParser\Node\Expr\Instanceof_(
+					return new BooleanNot(
+						new Instanceof_(
 							$expr->value,
-							new \PhpParser\Node\Name($classType->getValue())
+							new Name($classType->getValue())
 						)
 					);
 				},
-				'implementsInterface' => function (Scope $scope, Arg $expr, Arg $class): ?\PhpParser\Node\Expr {
+				'implementsInterface' => static function (Scope $scope, Arg $expr, Arg $class): ?Expr {
 					$classType = $scope->getType($class->value);
 					if (!$classType instanceof ConstantStringType) {
 						return null;
 					}
 
-					return new \PhpParser\Node\Expr\Instanceof_(
+					return new Instanceof_(
 						$expr->value,
-						new \PhpParser\Node\Name($classType->getValue())
+						new Name($classType->getValue())
 					);
 				},
-				'keyExists' => function (Scope $scope, Arg $array, Arg $key): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('array_key_exists'),
+				'keyExists' => static function (Scope $scope, Arg $array, Arg $key): Expr {
+					return new FuncCall(
+						new Name('array_key_exists'),
 						[$key, $array]
 					);
 				},
-				'keyNotExists' => function (Scope $scope, Arg $array, Arg $key): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BooleanNot(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('array_key_exists'),
+				'keyNotExists' => static function (Scope $scope, Arg $array, Arg $key): Expr {
+					return new BooleanNot(
+						new FuncCall(
+							new Name('array_key_exists'),
 							[$key, $array]
 						)
 					);
 				},
-				'validArrayKey' => function (Scope $scope, Arg $value): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_int'),
+				'validArrayKey' => static function (Scope $scope, Arg $value): Expr {
+					return new BooleanOr(
+						new FuncCall(
+							new Name('is_int'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						)
 					);
 				},
-				'true' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\Identical(
+				'true' => static function (Scope $scope, Arg $expr): Expr {
+					return new Identical(
 						$expr->value,
-						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('true'))
+						new ConstFetch(new Name('true'))
 					);
 				},
-				'false' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\Identical(
+				'false' => static function (Scope $scope, Arg $expr): Expr {
+					return new Identical(
 						$expr->value,
-						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('false'))
+						new ConstFetch(new Name('false'))
 					);
 				},
-				'null' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\Identical(
+				'null' => static function (Scope $scope, Arg $expr): Expr {
+					return new Identical(
 						$expr->value,
-						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('null'))
+						new ConstFetch(new Name('null'))
 					);
 				},
-				'notFalse' => static function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\NotIdentical(
+				'notFalse' => static function (Scope $scope, Arg $expr): Expr {
+					return new NotIdentical(
 						$expr->value,
-						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('false'))
+						new ConstFetch(new Name('false'))
 					);
 				},
-				'notNull' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\NotIdentical(
+				'notNull' => static function (Scope $scope, Arg $expr): Expr {
+					return new NotIdentical(
 						$expr->value,
-						new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('null'))
+						new ConstFetch(new Name('null'))
 					);
 				},
-				'same' => function (Scope $scope, Arg $value1, Arg $value2): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\Identical(
+				'same' => static function (Scope $scope, Arg $value1, Arg $value2): Expr {
+					return new Identical(
 						$value1->value,
 						$value2->value
 					);
 				},
-				'notSame' => function (Scope $scope, Arg $value1, Arg $value2): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\NotIdentical(
+				'notSame' => static function (Scope $scope, Arg $value1, Arg $value2): Expr {
+					return new NotIdentical(
 						$value1->value,
 						$value2->value
 					);
 				},
-				'subclassOf' => function (Scope $scope, Arg $expr, Arg $class): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('is_subclass_of'),
+				'subclassOf' => static function (Scope $scope, Arg $expr, Arg $class): Expr {
+					return new FuncCall(
+						new Name('is_subclass_of'),
 						[
 							new Arg($expr->value),
 							$class,
 						]
 					);
 				},
-				'classExists' => function (Scope $scope, Arg $class): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('class_exists'),
+				'classExists' => static function (Scope $scope, Arg $class): Expr {
+					return new FuncCall(
+						new Name('class_exists'),
 						[$class]
 					);
 				},
-				'interfaceExists' => function (Scope $scope, Arg $class): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('interface_exists'),
+				'interfaceExists' => static function (Scope $scope, Arg $class): Expr {
+					return new FuncCall(
+						new Name('interface_exists'),
 						[$class]
 					);
 				},
-				'count' => function (Scope $scope, Arg $array, Arg $number): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\Identical(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('count'),
+				'count' => static function (Scope $scope, Arg $array, Arg $number): Expr {
+					return new Identical(
+						new FuncCall(
+							new Name('count'),
 							[$array]
 						),
 						$number->value
 					);
 				},
-				'minCount' => function (Scope $scope, Arg $array, Arg $min): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('count'),
+				'minCount' => static function (Scope $scope, Arg $array, Arg $min): Expr {
+					return new GreaterOrEqual(
+						new FuncCall(
+							new Name('count'),
 							[$array]
 						),
 						$min->value
 					);
 				},
-				'maxCount' => function (Scope $scope, Arg $array, Arg $max): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\SmallerOrEqual(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('count'),
+				'maxCount' => static function (Scope $scope, Arg $array, Arg $max): Expr {
+					return new SmallerOrEqual(
+						new FuncCall(
+							new Name('count'),
 							[$array]
 						),
 						$max->value
 					);
 				},
-				'countBetween' => function (Scope $scope, Arg $array, Arg $min, Arg $max): \PhpParser\Node\Expr {
+				'countBetween' => static function (Scope $scope, Arg $array, Arg $min, Arg $max): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('count'),
+						new GreaterOrEqual(
+							new FuncCall(
+								new Name('count'),
 								[$array]
 							),
 							$min->value
 						),
-						new \PhpParser\Node\Expr\BinaryOp\SmallerOrEqual(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('count'),
+						new SmallerOrEqual(
+							new FuncCall(
+								new Name('count'),
 								[$array]
 							),
 							$max->value
 						)
 					);
 				},
-				'length' => function (Scope $scope, Arg $value, Arg $length): \PhpParser\Node\Expr {
+				'length' => static function (Scope $scope, Arg $value, Arg $length): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\BinaryOp\Identical(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('strlen'),
+						new Identical(
+							new FuncCall(
+								new Name('strlen'),
 								[$value]
 							),
 							$length->value
 						)
 					);
 				},
-				'minLength' => function (Scope $scope, Arg $value, Arg $min): \PhpParser\Node\Expr {
+				'minLength' => static function (Scope $scope, Arg $value, Arg $min): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('strlen'),
+						new GreaterOrEqual(
+							new FuncCall(
+								new Name('strlen'),
 								[$value]
 							),
 							$min->value
 						)
 					);
 				},
-				'maxLength' => function (Scope $scope, Arg $value, Arg $max): \PhpParser\Node\Expr {
+				'maxLength' => static function (Scope $scope, Arg $value, Arg $max): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						),
-						new \PhpParser\Node\Expr\BinaryOp\SmallerOrEqual(
-							new \PhpParser\Node\Expr\FuncCall(
-								new \PhpParser\Node\Name('strlen'),
+						new SmallerOrEqual(
+							new FuncCall(
+								new Name('strlen'),
 								[$value]
 							),
 							$max->value
 						)
 					);
 				},
-				'lengthBetween' => function (Scope $scope, Arg $value, Arg $min, Arg $max): \PhpParser\Node\Expr {
+				'lengthBetween' => static function (Scope $scope, Arg $value, Arg $min, Arg $max): Expr {
 					return new BooleanAnd(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_string'),
+						new FuncCall(
+							new Name('is_string'),
 							[$value]
 						),
 						new BooleanAnd(
-							new \PhpParser\Node\Expr\BinaryOp\GreaterOrEqual(
-								new \PhpParser\Node\Expr\FuncCall(
-									new \PhpParser\Node\Name('strlen'),
+							new GreaterOrEqual(
+								new FuncCall(
+									new Name('strlen'),
 									[$value]
 								),
 								$min->value
 							),
-							new \PhpParser\Node\Expr\BinaryOp\SmallerOrEqual(
-								new \PhpParser\Node\Expr\FuncCall(
-									new \PhpParser\Node\Name('strlen'),
+							new SmallerOrEqual(
+								new FuncCall(
+									new Name('strlen'),
 									[$value]
 								),
 								$max->value
@@ -541,47 +562,47 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						)
 					);
 				},
-				'inArray' => function (Scope $scope, Arg $needle, Arg $array): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('in_array'),
+				'inArray' => static function (Scope $scope, Arg $needle, Arg $array): Expr {
+					return new FuncCall(
+						new Name('in_array'),
 						[
 							$needle,
 							$array,
-							new Arg(new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('true'))),
+							new Arg(new ConstFetch(new Name('true'))),
 						]
 					);
 				},
-				'oneOf' => function (Scope $scope, Arg $needle, Arg $array): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('in_array'),
+				'oneOf' => static function (Scope $scope, Arg $needle, Arg $array): Expr {
+					return new FuncCall(
+						new Name('in_array'),
 						[
 							$needle,
 							$array,
-							new Arg(new \PhpParser\Node\Expr\ConstFetch(new \PhpParser\Node\Name('true'))),
+							new Arg(new ConstFetch(new Name('true'))),
 						]
 					);
 				},
-				'methodExists' => function (Scope $scope, Arg $object, Arg $method): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('method_exists'),
+				'methodExists' => static function (Scope $scope, Arg $object, Arg $method): Expr {
+					return new FuncCall(
+						new Name('method_exists'),
 						[$object, $method]
 					);
 				},
-				'propertyExists' => function (Scope $scope, Arg $object, Arg $property): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\FuncCall(
-						new \PhpParser\Node\Name('property_exists'),
+				'propertyExists' => static function (Scope $scope, Arg $object, Arg $property): Expr {
+					return new FuncCall(
+						new Name('property_exists'),
 						[$object, $property]
 					);
 				},
-				'isArrayAccessible' => function (Scope $scope, Arg $expr): \PhpParser\Node\Expr {
-					return new \PhpParser\Node\Expr\BinaryOp\BooleanOr(
-						new \PhpParser\Node\Expr\FuncCall(
-							new \PhpParser\Node\Name('is_array'),
+				'isArrayAccessible' => static function (Scope $scope, Arg $expr): Expr {
+					return new BooleanOr(
+						new FuncCall(
+							new Name('is_array'),
 							[$expr]
 						),
-						new \PhpParser\Node\Expr\Instanceof_(
+						new Instanceof_(
 							$expr->value,
-							new \PhpParser\Node\Name(\ArrayAccess::class)
+							new Name(ArrayAccess::class)
 						)
 					);
 				},
@@ -601,7 +622,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			return $this->arrayOrIterable(
 				$scope,
 				$node->getArgs()[0]->value,
-				function (Type $type): Type {
+				static function (Type $type): Type {
 					return TypeCombinator::removeNull($type);
 				}
 			);
@@ -617,7 +638,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			return $this->arrayOrIterable(
 				$scope,
 				$node->getArgs()[0]->value,
-				function (Type $type) use ($objectType): Type {
+				static function (Type $type) use ($objectType): Type {
 					return TypeCombinator::remove($type, $objectType);
 				}
 			);
@@ -628,19 +649,19 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			return $this->arrayOrIterable(
 				$scope,
 				$node->getArgs()[0]->value,
-				function (Type $type) use ($valueType): Type {
+				static function (Type $type) use ($valueType): Type {
 					return TypeCombinator::remove($type, $valueType);
 				}
 			);
 		}
 
-		throw new \PHPStan\ShouldNotHappenException();
+		throw new ShouldNotHappenException();
 	}
 
 	private function arrayOrIterable(
 		Scope $scope,
-		\PhpParser\Node\Expr $expr,
-		\Closure $typeCallback
+		Expr $expr,
+		Closure $typeCallback
 	): SpecifiedTypes
 	{
 		$currentType = TypeCombinator::intersect($scope->getType($expr), new IterableType(new MixedType(), new MixedType()));

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -22,8 +22,6 @@ class AssertTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 
 	/**
 	 * @dataProvider dataFileAsserts
-	 * @param string $assertType
-	 * @param string $file
 	 * @param mixed ...$args
 	 */
 	public function testFileAsserts(

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -4,11 +4,12 @@ namespace PHPStan\Type\WebMozartAssert;
 
 use PHPStan\Rules\Comparison\ImpossibleCheckTypeStaticMethodCallRule;
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends \PHPStan\Testing\RuleTestCase<ImpossibleCheckTypeStaticMethodCallRule>
+ * @extends RuleTestCase<ImpossibleCheckTypeStaticMethodCallRule>
  */
-class ImpossibleCheckTypeMethodCallRuleTest extends \PHPStan\Testing\RuleTestCase
+class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule


### PR DESCRIPTION
PR title does already not match anymore.

This brings in changes similar to the following from phpstan-src
- https://github.com/phpstan/phpstan-src/commit/7bf2f0cbfcd9f5698dd2d0ee5b1aa937ada6df87
- https://github.com/phpstan/phpstan-src/commit/ee2499ebe6d0ef59c93a82b19a82b7ee6195c225
- https://github.com/phpstan/phpstan-src/commit/0f2fbfff2d861e17345981f2c02ab7696a2298e3
- https://github.com/phpstan/phpstan-src/commit/8737c3b4690661445338db2a6c31d340a0eac4bd

I also compared and synced phpcs.xml manually, adopting everything that makes sense. The only differences should now be a couple of sniffs related to null coalescing, union types, arrow functions, trailing function calls and so.
<details>
  <summary>Diff to phpstan-src</summary>

`diff -uw phpstan-src/phpcs.xml phpstan-webmozart-assert/phpcs.xml`

```diff
--- phpstan-src/phpcs.xml	2022-01-07 10:16:03.000000000 +0100
+++ phpstan-webmozart-assert/phpcs.xml	2022-01-19 10:40:27.000000000 +0100
@@ -1,17 +1,14 @@
 <?xml version="1.0"?>
-<ruleset name="PHPStan">
+<ruleset name="PHPStan webmozart/assert extension">
 	<config name="php_version" value="70100"/>
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="utf-8"/>
 	<arg name="tab-width" value="4"/>
 	<arg name="cache" value="tmp/cache/phpcs"/>
-	<arg name="ignore" value="compiler/tests/*/data,tests/*/data,tests/*/traits,tests/notAutoloaded,tests/*/cache,src/Reflection/SignatureMap/functionMap.php,tests/e2e/magic-setter,tests/e2e/anon-class"/>
 	<arg value="sp"/>
 	<file>src</file>
 	<file>tests</file>
-	<file>compiler/src</file>
-	<file>compiler/tests</file>

 	<rule ref="build-cs/vendor/consistence-community/coding-standard/Consistence/ruleset.xml">
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
@@ -36,19 +33,12 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
 		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
-		<properties>
-			<property name="enableObjectTypeHint" value="true"/>
-		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation">
 		<severity>10</severity>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
 		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
-		<properties>
-			<property name="enableNativeTypeHint" value="true"/>
-			<property name="enableUnionTypeHint" value="true"/>
-		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation">
 		<severity>10</severity>
@@ -56,30 +46,14 @@
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
 		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
 		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint"/>
-		<properties>
-			<property name="enableObjectTypeHint" value="true"/>
-		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation">
 		<severity>10</severity>
 	</rule>
-	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure.UnusedInheritedVariable">
-		<exclude-pattern>src/Command/CommandHelper.php</exclude-pattern>
-		<exclude-pattern>src/Testing/PHPStanTestCase.php</exclude-pattern>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException">
-		<exclude-pattern>tests</exclude-pattern>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable">
-		<exclude-pattern>src/Command/AnalyseApplication.php</exclude-pattern>
-	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure.UnusedInheritedVariable"/>
+	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
 	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
 		<exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElseIf"/>
 	</rule>
@@ -88,12 +62,10 @@
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>
 			<property name="rootNamespaces" type="array">
-				<element key="compiler/src" value="PHPStan\Compiler"/>
-				<element key="compiler/tests" value="PHPStan\Compiler"/>
 				<element key="src" value="PHPStan"/>
-				<element key="tests/PHPStan" value="PHPStan"/>
-				<element key="tests/e2e" value="PHPStan\Tests"/>
+				<element key="tests" value="PHPStan"/>
 			</property>
+
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
@@ -131,54 +103,8 @@
 			<property name="spacingAfterLast" value="1"/>
 		</properties>
 	</rule>
-	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-		<exclude-pattern>src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php</exclude-pattern>
-	</rule>
-	<rule ref="Consistence.NamingConventions.ValidVariableName.NotCamelCaps">
-		<exclude-pattern>src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php</exclude-pattern>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
-	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
-		<properties>
-			<property name="enable" value="true"/>
-			<property name="withSpaces" value="no"/>
-			<property name="nullPosition" value="last"/>
-		</properties>
-	</rule>
-	<rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion">
-		<properties>
-			<property name="enable" value="true"/>
-		</properties>
-	</rule>
-	<exclude-pattern>tests/*/data</exclude-pattern>
-	<exclude-pattern>tests/*/Fixture</exclude-pattern>
-	<exclude-pattern>tests/e2e/resultCache_1.php</exclude-pattern>
-	<exclude-pattern>tests/e2e/resultCache_2.php</exclude-pattern>
-	<exclude-pattern>tests/e2e/resultCache_3.php</exclude-pattern>
-	<exclude-pattern>tests/*/traits</exclude-pattern>
+	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+	<rule ref="Consistence.NamingConventions.ValidVariableName.NotCamelCaps"/>
 	<exclude-pattern>tests/tmp</exclude-pattern>
-	<exclude-pattern>tests/notAutoloaded</exclude-pattern>
-	<exclude-pattern>src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php</exclude-pattern>
-	<exclude-pattern>src/Reflection/SignatureMap/functionMap.php</exclude-pattern>
-	<exclude-pattern>src/Reflection/SignatureMap/functionMetadata.php</exclude-pattern>
+	<exclude-pattern>tests/*/data</exclude-pattern>
 </ruleset>
```
</details>