### PR TITLE
[Issue] Try to reproduce `Call to static method Webmozart\Assert\Assert::uuid() with non-empty-string will always evaluate to true.`

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -26,6 +26,16 @@ class ImpossibleCheckTypeMethodCallRuleTest extends \PHPStan\Testing\RuleTestCas
 		]);
 	}
 
+	public function testExtensionFalsePositive(): void
+	{
+		$this->analyse([__DIR__ . '/data/impossible-check_false-positive.php'], [
+			[
+				'Call to static method Webmozart\Assert\Assert::uuid() with \'\' will always evaluate to false.',
+				13,
+			],
+		]);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Type/WebMozartAssert/data/impossible-check_false-positive.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check_false-positive.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WebmozartAssertImpossibleCheck;
+
+use Webmozart\Assert\Assert;
+
+class Foo
+{
+	public function uuid(string $s): void
+	{
+		Assert::stringNotEmpty($s);
+		Assert::uuid($s);
+	}
+
+}


### PR DESCRIPTION
_I fail to reproduce it in test case but it's kind of hard to debug tests since they're loaded from phar and not very flexible then._

I'm getting:
> Call to static method Webmozart\Assert\Assert::uuid() with non-empty-string will always evaluate to true.

```php
Assert::stringNotEmpty($id); // I need both in order to have more precise assertion message
Assert::uuid($id);
```

with phpstan v1.4 and 1.0.7 extesnion


