### PR TITLE
Fix a couple of nullOr* tests

### DIFF
--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -7,7 +7,7 @@ use Webmozart\Assert\Assert;
 class TestStrings
 {
 
-	public function length(string $a, string $b, string $c): void
+	public function length(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::length($a, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
@@ -16,10 +16,13 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string', $b);
 
 		Assert::nullOrLength($c, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $c); // should be non-empty-string|null
+		\PHPStan\Testing\assertType('non-empty-string', $c);
+
+		Assert::nullOrLength($d, 1);
+		\PHPStan\Testing\assertType('string|null', $d); // should be non-empty-string|null
 	}
 
-	public function minLength(string $a, string $b, string $c): void
+	public function minLength(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::minLength($a, 0);
 		\PHPStan\Testing\assertType('string', $a);
@@ -28,10 +31,13 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string', $b);
 
 		Assert::nullOrMinLength($c, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $c); // should be non-empty-string|null
+		\PHPStan\Testing\assertType('non-empty-string', $c);
+
+		Assert::nullOrMinLength($d, 1);
+		\PHPStan\Testing\assertType('string|null', $d); // should be non-empty-string|null
 	}
 
-	public function maxLength(string $a, string $b, string $c): void
+	public function maxLength(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::maxLength($a, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
@@ -40,10 +46,13 @@ class TestStrings
 		\PHPStan\Testing\assertType('string', $b);
 
 		Assert::nullOrMaxLength($c, 1);
-		\PHPStan\Testing\assertType('string', $c);  // should be string|null
+		\PHPStan\Testing\assertType('string', $c);
+
+		Assert::nullOrMaxLength($d, 1);
+		\PHPStan\Testing\assertType('string|null', $d);
 	}
 
-	public function lengthBetween(string $a, string $b, string $c, string $d, string $e): void
+	public function lengthBetween(string $a, string $b, string $c, string $d, string $e, ?string $f): void
 	{
 		Assert::lengthBetween($a, 0, 0);
 		\PHPStan\Testing\assertType('\'\'', $a);
@@ -58,7 +67,10 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string', $d);
 
 		Assert::nullOrLengthBetween($e, 1, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $e); // should be non-empty-string|null
+		\PHPStan\Testing\assertType('non-empty-string', $e);
+
+		Assert::nullOrLengthBetween($f, 1, 1);
+		\PHPStan\Testing\assertType('string|null', $f); // should be non-empty-string|null
 	}
 
 }


### PR DESCRIPTION
Some of them tried to make `string` nullable which won't work. But those tests are good anyways. Added a couple more that show that `string|null` is not correctly narrowed down to `non-empty-string|null`.

This should be a good basis now for adaptions, I hope :)