### PR TITLE
Improve isList

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -307,9 +307,18 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					);
 				},
 				'isList' => static function (Scope $scope, Arg $expr): Expr {
-					return new FuncCall(
-						new Name('is_array'),
-						[$expr]
+					return new BooleanAnd(
+						new FuncCall(
+							new Name('is_array'),
+							[$expr]
+						),
+						new Identical(
+							$expr->value,
+							new FuncCall(
+								new Name('array_values'),
+								[$expr]
+							)
+						)
 					);
 				},
 				'isCountable' => static function (Scope $scope, Arg $expr): Expr {

--- a/tests/Type/WebMozartAssert/data/array.php
+++ b/tests/Type/WebMozartAssert/data/array.php
@@ -100,10 +100,10 @@ class ArrayTest
 	public function isList($a, $b): void
 	{
 		Assert::isList($a);
-		\PHPStan\Testing\assertType('array', $a);
+		\PHPStan\Testing\assertType('array<int, mixed>', $a);
 
 		Assert::nullOrIsList($b);
-		\PHPStan\Testing\assertType('array|null', $b);
+		\PHPStan\Testing\assertType('array<int, mixed>|null', $b);
 	}
 
 }


### PR DESCRIPTION
Narrows down the type to `array<int, mixed>` instead of just `array`. I'm surprised that PHPStan understands that expression tbh :)