### PR TITLE
Allow objects in instanceof-like assertions

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -24,6 +24,26 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::stringNotEmpty() with \'\' will always evaluate to false.',
 				13,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::isInstanceOf() with WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
+				21,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::isInstanceOf() with WebmozartAssertImpossibleCheck\Bar and WebmozartAssertImpossibleCheck\Bar will always evaluate to true.',
+				22,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::nullOrIsInstanceOf() with WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
+				23,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::allIsInstanceOf() with array<WebmozartAssertImpossibleCheck\Bar> and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
+				26,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::notInstanceOf() with WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to false.',
+				32,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\WebMozartAssert;
 
+use stdClass;
 use Webmozart\Assert\Assert;
 
 class CollectionTest
@@ -28,19 +29,33 @@ class CollectionTest
 		\PHPStan\Testing\assertType('iterable<int>', $b);
 	}
 
-	public function allInstanceOf(array $a): void
+	public function allInstanceOf(array $a, array $b, array $c): void
 	{
-		Assert::allIsInstanceOf($a, \stdClass::class);
+		Assert::allIsInstanceOf($a, stdClass::class);
 		\PHPStan\Testing\assertType('array<stdClass>', $a);
+
+		Assert::allIsInstanceOf($b, new stdClass());
+		\PHPStan\Testing\assertType('array<stdClass>', $b);
+
+		Assert::allIsInstanceOf($c, 17);
+		\PHPStan\Testing\assertType('array', $c);
 	}
 
 	/**
 	 * @param (CollectionFoo|CollectionBar)[] $a
+	 * @param (CollectionFoo|stdClass)[] $b
+	 * @param CollectionFoo[] $c
 	 */
-	public function allNotInstanceOf(array $a): void
+	public function allNotInstanceOf(array $a, array $b, array $c): void
 	{
 		Assert::allNotInstanceOf($a, CollectionBar::class);
 		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $a);
+
+		Assert::allNotInstanceOf($b, new stdClass());
+		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $b);
+
+		Assert::allNotInstanceOf($c, 17);
+		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $c);
 	}
 
 	/**

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -13,4 +13,27 @@ class Foo
 		Assert::stringNotEmpty('');
 	}
 
+	/**
+	 * @param mixed[] $b
+	 */
+	public function isInstanceOf(Bar $a, array $b): void
+	{
+		Assert::isInstanceOf($a, Bar::class);
+		Assert::isInstanceOf($a, $a);
+		Assert::nullOrIsInstanceOf($a, Bar::class);
+
+		Assert::allIsInstanceOf($b, Bar::class);
+		Assert::allIsInstanceOf($b, Bar::class);
+	}
+
+	public function notInstanceOf(Bar $a): void
+	{
+		Assert::notInstanceOf($a, Baz::class);
+		Assert::notInstanceOf($a, Bar::class);
+	}
+
 }
+
+interface Bar {};
+
+class Baz {}

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\WebMozartAssert;
 
+use stdClass;
 use Webmozart\Assert\Assert;
 
 class TypeTest
@@ -158,22 +159,36 @@ class TypeTest
 		\PHPStan\Testing\assertType('array|Countable|null', $b);
 	}
 
-	public function isInstanceOf($a, $b): void
+	public function isInstanceOf($a, $b, $c, $d): void
 	{
 		Assert::isInstanceOf($a, self::class);
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest', $a);
 
 		Assert::nullOrIsInstanceOf($b, self::class);
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest|null', $b);
+
+		Assert::isInstanceOf($c, new stdClass());
+		\PHPStan\Testing\assertType('stdClass', $c);
+
+		Assert::isInstanceOf($d, 17);
+		\PHPStan\Testing\assertType('mixed', $d);
 	}
 
 	/**
 	 * @param Foo|Bar $a
+	 * @param Foo|stdClass $b
+	 * @param Foo|Bar $c
 	 */
-	public function notInstanceOf($a): void
+	public function notInstanceOf($a, $b, $c): void
 	{
 		Assert::notInstanceOf($a, Bar::class);
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Foo', $a);
+
+		Assert::notInstanceOf($b, new stdClass());
+		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Foo', $b);
+
+		Assert::notInstanceOf($c, 17);
+		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Bar|PHPStan\Type\WebMozartAssert\Foo', $c);
 	}
 
 	public function isArrayAccessible($a, $b): void


### PR DESCRIPTION
Affected assertions and their webmozart implementations showing objects are allowed
- `isInstanceOf` / `notInstanceOf` - https://github.com/webmozarts/assert/blob/1.10.0/src/Assert.php#L411 / https://github.com/webmozarts/assert/blob/1.10.0/src/Assert.php#L434 using [instanceof](https://www.php.net/manual/en/language.operators.type.php#example-127)