### PR TITLE
Support isNonEmptyList and isNonEmptyMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ This extension specifies types of values passed to:
 * `Assert::maxCount`
 * `Assert::countBetween`
 * `Assert::isList`
+* `Assert::isNonEmptyList`
 * `Assert::isMap`
+* `Assert::isNonEmptyMap`
 * `Assert::inArray`
 * `Assert::oneOf`
 * `Assert::methodExists`

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -331,6 +331,15 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						)
 					);
 				},
+				'isNonEmptyList' => static function (Scope $scope, Arg $expr): Expr {
+					return new BooleanAnd(
+						self::$resolvers['isList']($scope, $expr),
+						new NotIdentical(
+							$expr->value,
+							new Array_()
+						)
+					);
+				},
 				'isMap' => static function (Scope $scope, Arg $expr): Expr {
 					return new BooleanAnd(
 						new FuncCall(
@@ -343,6 +352,15 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 								[$expr, new Arg(new String_('is_string')), new Arg(new ConstFetch(new Name('ARRAY_FILTER_USE_KEY')))]
 							),
 							$expr->value
+						)
+					);
+				},
+				'isNonEmptyMap' => static function (Scope $scope, Arg $expr): Expr {
+					return new BooleanAnd(
+						self::$resolvers['isMap']($scope, $expr),
+						new NotIdentical(
+							$expr->value,
+							new Array_()
 						)
 					);
 				},

--- a/tests/Type/WebMozartAssert/data/array.php
+++ b/tests/Type/WebMozartAssert/data/array.php
@@ -106,6 +106,15 @@ class ArrayTest
 		\PHPStan\Testing\assertType('array<int, mixed>|null', $b);
 	}
 
+	public function isNonEmptyList($a, $b): void
+	{
+		Assert::isNonEmptyList($a);
+		\PHPStan\Testing\assertType('non-empty-array<int, mixed>', $a);
+
+		Assert::nullOrIsNonEmptyList($b);
+		\PHPStan\Testing\assertType('non-empty-array<int, mixed>|null', $b);
+	}
+
 	public function isMap($a, $b): void
 	{
 		Assert::isMap($a);
@@ -113,6 +122,15 @@ class ArrayTest
 
 		Assert::nullOrIsMap($b);
 		\PHPStan\Testing\assertType('array<string, mixed>|null', $b);
+	}
+
+	public function isNonEmptyMap($a, $b): void
+	{
+		Assert::isNonEmptyMap($a);
+		\PHPStan\Testing\assertType('non-empty-array<string, mixed>', $a);
+
+		Assert::nullOrIsNonEmptyMap($b);
+		\PHPStan\Testing\assertType('non-empty-array<string, mixed>|null', $b);
 	}
 
 }


### PR DESCRIPTION
I guess this closes #63.

It creates the types at least, that PHPStan is currently capable to handle. Should be fine IMO :) If not, I can edit my bug xD