### PR TITLE
Support isAOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This extension specifies types of values passed to:
 * `Assert::isCountable`
 * `Assert::isInstanceOf`
 * `Assert::notInstanceOf`
+* `Assert::isAOf`
 * `Assert::subclassOf`
 * `Assert::true`
 * `Assert::false`

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -37,6 +37,7 @@ use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -379,6 +380,15 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 							$expr->value,
 							$className
 						)
+					);
+				},
+				'isAOf' => static function (Scope $scope, Arg $expr, Arg $class): Expr {
+					$exprType = $scope->getType($expr->value);
+					$allowString = (new StringType())->isSuperTypeOf($exprType)->yes();
+
+					return new FuncCall(
+						new Name('is_a'),
+						[$expr, $class, new Arg(new ConstFetch(new Name($allowString ? 'true' : 'false')))]
 					);
 				},
 				'implementsInterface' => static function (Scope $scope, Arg $expr, Arg $class): ?Expr {

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -191,6 +191,24 @@ class TypeTest
 		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Bar|PHPStan\Type\WebMozartAssert\Foo', $c);
 	}
 
+	public function isAOf($a, $b, string $c): void
+	{
+		Assert::isAOf($a, stdClass::class);
+		\PHPStan\Testing\assertType('stdClass', $a);
+
+		Assert::isAOf(Foo::class, stdClass::class);
+		\PHPStan\Testing\assertType('*NEVER*', Foo::class);
+
+		Assert::isAOf(Bar::class, stdClass::class);
+		\PHPStan\Testing\assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Bar\'', Bar::class);
+
+		Assert::nullOrIsAOf($b, stdClass::class);
+		\PHPStan\Testing\assertType('stdClass|null', $b);
+
+		Assert::isAOf($c, stdClass::class);
+		\PHPStan\Testing\assertType('class-string<stdClass>', $c);
+	}
+
 	public function isArrayAccessible($a, $b): void
 	{
 		Assert::isArrayAccessible($a);
@@ -200,3 +218,7 @@ class TypeTest
 		\PHPStan\Testing\assertType('array|ArrayAccess|null', $b);
 	}
 }
+
+class Foo {}
+
+class Bar extends stdClass {}


### PR DESCRIPTION
Wanted to add support for `isNotA` here too, but PHPStan does currently not resolve a couple edge case types there correctly. Maybe I'll look into that more and raise a PR in PHPStan if possible..

Fyi webmozart-assert is just allowing strings in case the first arg is one, see https://github.com/webmozarts/assert/blob/8403a941039e7a9534e877f0bb38b8d9faa48f01/src/Assert.php#L486 and https://www.php.net/manual/en/function.is-a.php which is why I replicated that behaviour here too.