### PR TITLE
Add regression test

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -47,6 +47,11 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug33(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-33.php'], []);
+	}
+
 	public function testBug68(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-68.php'], []);

--- a/tests/Type/WebMozartAssert/data/bug-33.php
+++ b/tests/Type/WebMozartAssert/data/bug-33.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug33;
+
+use Webmozart\Assert\Assert;
+
+class Bug33
+{
+
+	public function foo(?string $bar)
+	{
+		Assert::nullOrStringNotEmpty($bar);
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/33

Was fixed with https://github.com/phpstan/phpstan/issues/6696 / https://github.com/phpstan/phpstan-src/commit/cc6655f9311a738bc2dec6bad2c6e6b6b8173c81

Also double-checked here that this fails with PHPStan 1.4.6.

Looking forward already to the next phpstan and phpstan-webmozart-assert release. I'll try to take a look at a few more issues here, hopefully I can squeeze in a bit more :)