### PR TITLE
Support deprecated isTraversable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This extension specifies types of values passed to:
 * `Assert::resource`
 * `Assert::isCallable`
 * `Assert::isArray`
+* `Assert::isTraversable` (deprecated, use `isIterable` or `isInstanceOf` instead)
 * `Assert::isIterable`
 * `Assert::isCountable`
 * `Assert::isInstanceOf`

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -304,6 +304,9 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						[$value]
 					);
 				},
+				'isTraversable' => static function (Scope $scope, Arg $value): Expr {
+					return self::$resolvers['isIterable']($scope, $value);
+				},
 				'isIterable' => static function (Scope $scope, Arg $expr): Expr {
 					return new BooleanOr(
 						new FuncCall(

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -141,6 +141,15 @@ class TypeTest
 		\PHPStan\Testing\assertType('array|null', $b);
 	}
 
+	public function isTraversable($a, $b): void
+	{
+		Assert::isTraversable($a);
+		\PHPStan\Testing\assertType('array|Traversable', $a);
+
+		Assert::nullOrIsTraversable($b);
+		\PHPStan\Testing\assertType('array|Traversable|null', $b);
+	}
+
 	public function isIterable($a, $b): void
 	{
 		Assert::isIterable($a);


### PR DESCRIPTION
I've to admit, I'm slowly coming to the point where I'm looking for feature-completeness :) Thought it makes sense to support this deprecated method too (who knows how long it will exist /when v2 is released), but feel free to close of course if you disagree.

https://github.com/webmozarts/assert/blob/1.10.0/src/Assert.php#L319