### PR TITLE
Fix allSubclassOf test case

### DIFF
--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -79,8 +79,7 @@ class CollectionTest
 	public function allSubclassOf(array $a, $b): void
 	{
 		Assert::allSubclassOf($a, self::class);
-		// should array<PHPStan\Type\WebMozartAssert\CollectionTest>
-		\PHPStan\Testing\assertType('array<*NEVER*>', $a);
+		\PHPStan\Testing\assertType('array<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $a);
 
 		Assert::allSubclassOf($b, self::class);
 		\PHPStan\Testing\assertType('iterable<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $b);


### PR DESCRIPTION
Apparently this has been fixed in https://github.com/phpstan/phpstan-src/commit/73f14dbf82cf054f9ef7f57ffe3a2794e0e659e9 / https://github.com/phpstan/phpstan-src/pull/1039