### PR TITLE
Fix non-integer range comparisons

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -40,6 +40,7 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -485,31 +486,56 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						$value2->value
 					);
 				},
-				'greaterThan' => static function (Scope $scope, Arg $value, Arg $limit): Expr {
+				'greaterThan' => static function (Scope $scope, Arg $value, Arg $limit): ?Expr {
+					$valueType = $scope->getType($value->value);
+					if ((new IntegerType())->isSuperTypeOf($valueType)->no()) {
+						return null;
+					}
+
 					return new Greater(
 						$value->value,
 						$limit->value
 					);
 				},
-				'greaterThanEq' => static function (Scope $scope, Arg $value, Arg $limit): Expr {
+				'greaterThanEq' => static function (Scope $scope, Arg $value, Arg $limit): ?Expr {
+					$valueType = $scope->getType($value->value);
+					if ((new IntegerType())->isSuperTypeOf($valueType)->no()) {
+						return null;
+					}
+
 					return new GreaterOrEqual(
 						$value->value,
 						$limit->value
 					);
 				},
-				'lessThan' => static function (Scope $scope, Arg $value, Arg $limit): Expr {
+				'lessThan' => static function (Scope $scope, Arg $value, Arg $limit): ?Expr {
+					$valueType = $scope->getType($value->value);
+					if ((new IntegerType())->isSuperTypeOf($valueType)->no()) {
+						return null;
+					}
+
 					return new Smaller(
 						$value->value,
 						$limit->value
 					);
 				},
-				'lessThanEq' => static function (Scope $scope, Arg $value, Arg $limit): Expr {
+				'lessThanEq' => static function (Scope $scope, Arg $value, Arg $limit): ?Expr {
+					$valueType = $scope->getType($value->value);
+					if ((new IntegerType())->isSuperTypeOf($valueType)->no()) {
+						return null;
+					}
+
 					return new SmallerOrEqual(
 						$value->value,
 						$limit->value
 					);
 				},
-				'range' => static function (Scope $scope, Arg $value, Arg $min, Arg $max): Expr {
+				'range' => static function (Scope $scope, Arg $value, Arg $min, Arg $max): ?Expr {
+					$valueType = $scope->getType($value->value);
+					if ((new IntegerType())->isSuperTypeOf($valueType)->no()) {
+						return null;
+					}
+
 					return new BooleanAnd(
 						new GreaterOrEqual(
 							$value->value,

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -80,6 +80,16 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-85.php'], []);
 	}
 
+	public function testBug118(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-118.php'], []);
+	}
+
+	public function testBug119(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-119.php'], []);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Type/WebMozartAssert/data/bug-118.php
+++ b/tests/Type/WebMozartAssert/data/bug-118.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug118;
+
+use DateTime;
+use Webmozart\Assert\Assert;
+
+function test(float $a, DateTime $b): void
+{
+	Assert::range($a, 0, 1);
+	Assert::range($b, 123456789, 9876543321);
+}

--- a/tests/Type/WebMozartAssert/data/bug-119.php
+++ b/tests/Type/WebMozartAssert/data/bug-119.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug119;
+
+use DateTime;
+use Webmozart\Assert\Assert;
+
+function test(float $a, float $b, float $c, float $d, DateTime  $e): void
+{
+	Assert::greaterThan($a, 0);
+	Assert::greaterThanEq($b, 0);
+	Assert::lessThan($c, 0);
+	Assert::lessThanEq($d, 0);
+	Assert::greaterThanEq($e, 639828000);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/118
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/119

The problem is that range types are only supported for ints. See also https://phpstan.org/r/4c476dc8-d156-4f32-a733-207ba74133c5

If those assertions would be called with anything else, e.g. a float, the extensions would not add any additional type information and therefore lead to the errors described with strict-rules enabled.