### PR TITLE
Fix integerish

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.1 || ^8.0",
-		"phpstan/phpstan": "^1.4.7"
+		"phpstan/phpstan": "^1.4.8"
 	},
 	"require-dev": {
 		"nikic/php-parser": "^4.13.0",

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\Equal;
 use PhpParser\Node\Expr\BinaryOp\Greater;
 use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -19,6 +20,7 @@ use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Cast\Int_;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Instanceof_;
@@ -236,9 +238,17 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					);
 				},
 				'integerish' => static function (Scope $scope, Arg $value): Expr {
-					return new FuncCall(
-						new Name('is_numeric'),
-						[$value]
+					return new BooleanAnd(
+						new FuncCall(
+							new Name('is_numeric'),
+							[$value]
+						),
+						new Equal(
+							$value->value,
+							new Int_(
+								$value->value
+							)
+						)
 					);
 				},
 				'numeric' => static function (Scope $scope, Arg $value): Expr {

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -65,6 +65,11 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug32(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-32.php'], []);
+	}
+
 	public function testBug33(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-33.php'], []);

--- a/tests/Type/WebMozartAssert/data/bug-32.php
+++ b/tests/Type/WebMozartAssert/data/bug-32.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug32;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param numeric-string $numericString
+ */
+function test(float $float, int $int, string $numericString): void
+{
+	Assert::integerish($float);
+	Assert::integerish($int);
+	Assert::integerish($numericString);
+}

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -35,13 +35,28 @@ class TypeTest
 		\PHPStan\Testing\assertType('int|null', $b);
 	}
 
-	public function integerish($a, $b): void
+	/**
+	 * @param numeric-string $e
+	 */
+	public function integerish($a, $b, int $c, float $d, string $e, string $f): void
 	{
 		Assert::integerish($a);
 		\PHPStan\Testing\assertType('float|int|numeric-string', $a);
 
 		Assert::nullOrIntegerish($b);
 		\PHPStan\Testing\assertType('float|int|numeric-string|null', $b);
+
+		Assert::integerish($c);
+		\PHPStan\Testing\assertType('int', $c);
+
+		Assert::integerish($d);
+		\PHPStan\Testing\assertType('float', $d);
+
+		Assert::integerish($e);
+		\PHPStan\Testing\assertType('numeric-string', $e);
+
+		Assert::integerish($f);
+		\PHPStan\Testing\assertType('numeric-string', $f);
 	}
 
 	public function positiveInteger($a, $b, $c): void


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/32

Fixed via 2 steps
- Using the correct expression instead of only `is_numeric`, see https://github.com/webmozarts/assert/blob/1.10.0/src/Assert.php#L99
- PHPStan retaining the types in that loosely equals comparison, see https://github.com/phpstan/phpstan-src/pull/1046

So this fix only works with the next PHPStan version.