### PR TITLE
Add more impossible-check tests for stringNotEmpty

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -44,6 +44,22 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::notInstanceOf() with WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to false.',
 				32,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::stringNotEmpty() with non-empty-string will always evaluate to true.',
+				44,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::stringNotEmpty() with non-empty-string will always evaluate to true.',
+				46,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::nullOrStringNotEmpty() with non-empty-string will always evaluate to true.',
+				49,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::nullOrStringNotEmpty() with non-empty-string|null will always evaluate to true.',
+				53,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -32,6 +32,27 @@ class Foo
 		Assert::notInstanceOf($a, Bar::class);
 	}
 
+	/**
+	 * @param non-empty-string $b
+	 * @param non-empty-string|null $e
+	 */
+	public function stringNotEmpty(string $a, string $b, string $c, ?string $d, ?string $e): void
+	{
+		Assert::stringNotEmpty(null); // maybe this should report, similar as '' does too
+
+		Assert::stringNotEmpty($a);
+		Assert::stringNotEmpty($a);
+
+		Assert::stringNotEmpty($b);
+
+		Assert::nullOrStringNotEmpty($c);
+		Assert::nullOrStringNotEmpty($c);
+
+		Assert::nullOrStringNotEmpty($d);
+
+		Assert::nullOrStringNotEmpty($e);
+	}
+
 }
 
 interface Bar {};


### PR DESCRIPTION
Those tests are not doing much, the motivation is mostly to help avoid regressions when refactoring PHPStan's Identical type specification.