### PR TITLE
Refactor nullOr handling

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -794,9 +794,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 
 		$typeBefore = $scope->getType($node->getArgs()[0]->value);
 		$type = $this->determineVariableTypeFromSpecifiedTypes($typeBefore, $specifiedTypes);
-		if ($type === null) {
-			return new SpecifiedTypes();
-		}
 
 		return $this->arrayOrIterable(
 			$scope,
@@ -834,9 +831,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 
 		$typeBefore = $scope->getType($node->getArgs()[0]->value);
 		$type = $this->determineVariableTypeFromSpecifiedTypes($typeBefore, $specifiedTypes);
-		if ($type === null) {
-			return new SpecifiedTypes();
-		}
 
 		return $this->typeSpecifier->create($node->getArgs()[0]->value, TypeCombinator::addNull($type), TypeSpecifierContext::createTruthy(), false, $scope);
 	}
@@ -878,7 +872,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 		);
 	}
 
-	private function determineVariableTypeFromSpecifiedTypes(Type $typeBefore, SpecifiedTypes $specifiedTypes): ?Type
+	private function determineVariableTypeFromSpecifiedTypes(Type $typeBefore, SpecifiedTypes $specifiedTypes): Type
 	{
 		if (count($specifiedTypes->getSureTypes()) > 0) {
 			$sureTypes = $specifiedTypes->getSureTypes();
@@ -901,7 +895,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			return TypeCombinator::remove($typeBefore, $type);
 		}
 
-		return null;
+		throw new ShouldNotHappenException();
 	}
 
 	/**

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -792,8 +792,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			TypeSpecifierContext::createTruthy()
 		);
 
-		$typeBefore = $scope->getType($node->getArgs()[0]->value);
-		$type = $this->determineVariableTypeFromSpecifiedTypes($typeBefore, $specifiedTypes);
+		$type = $this->determineVariableTypeFromSpecifiedTypes($scope, $specifiedTypes);
 
 		return $this->arrayOrIterable(
 			$scope,
@@ -829,8 +828,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			TypeSpecifierContext::createTruthy()
 		);
 
-		$typeBefore = $scope->getType($node->getArgs()[0]->value);
-		$type = $this->determineVariableTypeFromSpecifiedTypes($typeBefore, $specifiedTypes);
+		$type = $this->determineVariableTypeFromSpecifiedTypes($scope, $specifiedTypes);
 
 		return $this->typeSpecifier->create($node->getArgs()[0]->value, TypeCombinator::addNull($type), TypeSpecifierContext::createTruthy(), false, $scope);
 	}
@@ -872,11 +870,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 		);
 	}
 
-	private function determineVariableTypeFromSpecifiedTypes(Type $typeBefore, SpecifiedTypes $specifiedTypes): Type
+	private function determineVariableTypeFromSpecifiedTypes(Scope $scope, SpecifiedTypes $specifiedTypes): Type
 	{
-		if (count($specifiedTypes->getSureTypes()) > 0) {
-			$sureTypes = $specifiedTypes->getSureTypes();
-			$sureNotTypes = $specifiedTypes->getSureNotTypes();
+		$sureTypes = $specifiedTypes->getSureTypes();
+		$sureNotTypes = $specifiedTypes->getSureNotTypes();
+
+		if (count($sureTypes) > 0) {
 			$exprString = key($sureTypes);
 			[, $type] = $sureTypes[$exprString];
 
@@ -887,12 +886,12 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			return $type;
 		}
 
-		if (count($specifiedTypes->getSureNotTypes()) > 0) {
+		if (count($sureNotTypes) > 0) {
 			$sureNotTypes = $specifiedTypes->getSureNotTypes();
 			$exprString = key($sureNotTypes);
-			[, $type] = $sureNotTypes[$exprString];
+			[$exprNode, $type] = $sureNotTypes[$exprString];
 
-			return TypeCombinator::remove($typeBefore, $type);
+			return TypeCombinator::remove($scope->getType($exprNode), $type);
 		}
 
 		throw new ShouldNotHappenException();


### PR DESCRIPTION
This is similar to the refactored `all` handling. It avoids building the core expression with invalid types by handling this differently. E.g. `int|null` is valid input for `nullOrGreaterThan` and we know that the core `greaterThan` expression would only be called with `int`. But this was not the case at the moment because it is building the expression and using information from the original type which still has the null. So this PR adapts that and should make the handling of all `nullOr` asserts safer by getting the right type when building the expression. It, obviously, has to add `null` back to the type later on, but I think this is more predictable than the current behaviour.

This is related to https://github.com/phpstan/phpstan-webmozart-assert/pull/120 and will help me use a stricter type checking approach there to fix the int-range assertions because I don't have the annoying null anymore.

Downside: I kind of started duplicating parts of `SpecifiedTypes::normalize` which is not part of the API yet. I don't have a problem with that, but if we want to make it part of the API I could get rid of most of the logic in `determineVariableTypeFromSpecifiedTypes`.