### PR TITLE
Support uuid, ip, ipv4, ipv6, email and notWhitespaceOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ This extension specifies types of values passed to:
 * `Assert::minLength`
 * `Assert::maxLength`
 * `Assert::lengthBetween`
+* `Assert::uuid`
+* `Assert::ip`
+* `Assert::ipv4`
+* `Assert::ipv6`
+* `Assert::email`
+* `Assert::notWhitespaceOnly`
 * `nullOr*` and `all*` variants of the above methods
 
 

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -713,6 +713,10 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					);
 				},
 			];
+
+			foreach (['uuid', 'ip', 'ipv4', 'ipv6', 'email', 'notWhitespaceOnly'] as $key) {
+				self::$resolvers[$key] = self::$resolvers['stringNotEmpty'];
+			}
 		}
 
 		return self::$resolvers;

--- a/tests/Type/WebMozartAssert/data/bug-85.php
+++ b/tests/Type/WebMozartAssert/data/bug-85.php
@@ -28,7 +28,7 @@ final class Bug85
 	public function baz(string $s): void
 	{
 		Assert::stringNotEmpty($s);
-		Assert::uuid($s);
+		Assert::digits($s);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -73,4 +73,39 @@ class TestStrings
 		\PHPStan\Testing\assertType('non-empty-string|null', $f);
 	}
 
+	public function uuid(string $a): void
+	{
+		Assert::uuid($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ip(string $a): void
+	{
+		Assert::ip($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ipv4(string $a): void
+	{
+		Assert::ipv4($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function ipv6(string $a): void
+	{
+		Assert::ipv6($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function email(string $a): void
+	{
+		Assert::email($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
+
+	public function notWhitespaceOnly(string $a): void
+	{
+		Assert::notWhitespaceOnly($a);
+		\PHPStan\Testing\assertType('non-empty-string', $a);
+	}
 }


### PR DESCRIPTION
I think we can safely say that a string passing one of those assertions is a non-empty string.