### PR TITLE
Fix 130

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -64,6 +64,10 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::nullOrStringNotEmpty() with non-empty-string|null will always evaluate to true.',
 				53,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::allCount() with array<non-empty-array> and 2 will always evaluate to true.',
+				76,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -179,6 +179,21 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-85.php'], []);
 	}
 
+	public function testBug118(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-118.php'], []);
+	}
+
+	public function testBug119(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-119.php'], []);
+	}
+
+	public function testBug130(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-130.php'], []);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Type/WebMozartAssert/data/bug-118.php
+++ b/tests/Type/WebMozartAssert/data/bug-118.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug118;
+
+use DateTime;
+use Webmozart\Assert\Assert;
+
+function test(float $a, DateTime $b): void
+{
+	Assert::range($a, 0, 1);
+	Assert::range($b, 123456789, 9876543321);
+}

--- a/tests/Type/WebMozartAssert/data/bug-119.php
+++ b/tests/Type/WebMozartAssert/data/bug-119.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebmozartAssertBug119;
+
+use DateTime;
+use Webmozart\Assert\Assert;
+
+function test(float $a, float $b, float $c, float $d, DateTime  $e): void
+{
+	Assert::greaterThan($a, 0);
+	Assert::greaterThanEq($b, 0);
+	Assert::lessThan($c, 0);
+	Assert::lessThanEq($d, 0);
+	Assert::greaterThanEq($e, 639828000);
+}

--- a/tests/Type/WebMozartAssert/data/bug-130.php
+++ b/tests/Type/WebMozartAssert/data/bug-130.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace WebmozartAssertBug130;
+
+use Webmozart\Assert\Assert;
+
+class Bug130
+{
+	/** @var array<int, array{id: string, num_order: string}> */
+	protected $orders = [];
+
+	public function setOrders(array $orders): self
+	{
+		Assert::allCount($orders, 2);
+		Assert::allKeyExists($orders, 'id');
+		Assert::allKeyExists($orders, 'num_order');
+
+		$this->orders = $orders;
+
+		return $this;
+	}
+}

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -120,6 +120,15 @@ class CollectionTest
 		\PHPStan\Testing\assertType('array<array&hasOffset(\'id\')>', $c);
 	}
 
+	/**
+	 * @param array<array> $a
+	 */
+	public function allCount(array $a): void
+	{
+		Assert::allCount($a, 2);
+		\PHPStan\Testing\assertType('array<non-empty-array>', $a);
+	}
+
 }
 
 class CollectionFoo

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -67,6 +67,15 @@ class Foo
 		Assert::notSame(Baz::create(), Baz::create());
 	}
 
+	/**
+	 * @param array<array> $a
+	 */
+	public function allCount(array $a): void
+	{
+		Assert::allCount($a, 2);
+		Assert::allCount($a, 2);
+	}
+
 }
 
 interface Bar {};


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/118
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/119
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/130

~~Looks like the rootExpr approach is potentially making problems if the same thing is asserted twice in a row, where previously it would detect the second one as always evaluating to true/false. But this could be related to the all* implementation here too.~~