### PR TITLE
Fix CS in test data

### DIFF
--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -146,15 +146,15 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8.php'], [
 			[
 				'Call to static method Webmozart\Assert\Assert::numeric() with numeric-string will always evaluate to true.',
-				15,
+				13,
 			],
 			[
 				'Call to static method Webmozart\Assert\Assert::numeric() with \'foo\' will always evaluate to false.',
-				16,
+				14,
 			],
 			[
 				'Call to static method Webmozart\Assert\Assert::numeric() with \'17.19\' will always evaluate to true.',
-				17,
+				15,
 			],
 		]);
 	}

--- a/tests/Type/WebMozartAssert/data/array.php
+++ b/tests/Type/WebMozartAssert/data/array.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\WebMozartAssert;
 
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
 
 class ArrayTest
 {
@@ -13,7 +14,7 @@ class ArrayTest
 	public function keyNotExists(array $a): void
 	{
 		Assert::keyNotExists($a, 'bar');
-		\PHPStan\Testing\assertType('array{foo?: string}', $a);
+		assertType('array{foo?: string}', $a);
 	}
 
 	/**
@@ -22,19 +23,19 @@ class ArrayTest
 	public function keyExists(array $a): void
 	{
 		Assert::keyExists($a, 'foo');
-		\PHPStan\Testing\assertType('array{foo: string, bar?: string}', $a);
+		assertType('array{foo: string, bar?: string}', $a);
 	}
 
 	public function validArrayKey($a, bool $b, $c): void
 	{
 		Assert::validArrayKey($a);
-		\PHPStan\Testing\assertType('int|string', $a);
+		assertType('int|string', $a);
 
 		Assert::validArrayKey($b);
-		\PHPStan\Testing\assertType('*NEVER*', $b);
+		assertType('*NEVER*', $b);
 
 		Assert::nullOrValidArrayKey($c);
-		\PHPStan\Testing\assertType('int|string|null', $c);
+		assertType('int|string|null', $c);
 	}
 
 	/**
@@ -44,10 +45,10 @@ class ArrayTest
 	public function count(array $a, array $b): void
 	{
 		Assert::count($a, 1);
-		\PHPStan\Testing\assertType('non-empty-array<int>', $a);
+		assertType('non-empty-array<int>', $a);
 
 		Assert::count($b, 0);
-		\PHPStan\Testing\assertType('array{}', $b);
+		assertType('array{}', $b);
 	}
 
 	/**
@@ -57,10 +58,10 @@ class ArrayTest
 	public function minCount(array $a, array $b): void
 	{
 		Assert::minCount($a, 1);
-		\PHPStan\Testing\assertType('non-empty-array<int>', $a);
+		assertType('non-empty-array<int>', $a);
 
 		Assert::minCount($b, 0);
-		\PHPStan\Testing\assertType('array<int>', $b);
+		assertType('array<int>', $b);
 	}
 
 	/**
@@ -70,10 +71,10 @@ class ArrayTest
 	public function maxCount(array $a, array $b): void
 	{
 		Assert::maxCount($a, 1);
-		\PHPStan\Testing\assertType('array<int>', $a);
+		assertType('array<int>', $a);
 
 		Assert::maxCount($b, 0);
-		\PHPStan\Testing\assertType('array{}', $b);
+		assertType('array{}', $b);
 	}
 
 	/**
@@ -85,52 +86,52 @@ class ArrayTest
 	public function countBetween(array $a, array $b, array $c, array $d): void
 	{
 		Assert::countBetween($a, 1, 2);
-		\PHPStan\Testing\assertType('non-empty-array<int>', $a);
+		assertType('non-empty-array<int>', $a);
 
 		Assert::countBetween($b, 0, 2);
-		\PHPStan\Testing\assertType('array<int>', $b);
+		assertType('array<int>', $b);
 
 		Assert::countBetween($c, 0, 0);
-		\PHPStan\Testing\assertType('array{}', $c);
+		assertType('array{}', $c);
 
 		Assert::countBetween($d, 2, 0);
-		\PHPStan\Testing\assertType('*NEVER*', $d);
+		assertType('*NEVER*', $d);
 	}
 
 	public function isList($a, $b): void
 	{
 		Assert::isList($a);
-		\PHPStan\Testing\assertType('array<int, mixed>', $a);
+		assertType('array<int, mixed>', $a);
 
 		Assert::nullOrIsList($b);
-		\PHPStan\Testing\assertType('array<int, mixed>|null', $b);
+		assertType('array<int, mixed>|null', $b);
 	}
 
 	public function isNonEmptyList($a, $b): void
 	{
 		Assert::isNonEmptyList($a);
-		\PHPStan\Testing\assertType('non-empty-array<int, mixed>', $a);
+		assertType('non-empty-array<int, mixed>', $a);
 
 		Assert::nullOrIsNonEmptyList($b);
-		\PHPStan\Testing\assertType('non-empty-array<int, mixed>|null', $b);
+		assertType('non-empty-array<int, mixed>|null', $b);
 	}
 
 	public function isMap($a, $b): void
 	{
 		Assert::isMap($a);
-		\PHPStan\Testing\assertType('array<string, mixed>', $a);
+		assertType('array<string, mixed>', $a);
 
 		Assert::nullOrIsMap($b);
-		\PHPStan\Testing\assertType('array<string, mixed>|null', $b);
+		assertType('array<string, mixed>|null', $b);
 	}
 
 	public function isNonEmptyMap($a, $b): void
 	{
 		Assert::isNonEmptyMap($a);
-		\PHPStan\Testing\assertType('non-empty-array<string, mixed>', $a);
+		assertType('non-empty-array<string, mixed>', $a);
 
 		Assert::nullOrIsNonEmptyMap($b);
-		\PHPStan\Testing\assertType('non-empty-array<string, mixed>|null', $b);
+		assertType('non-empty-array<string, mixed>|null', $b);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/bug-118.php
+++ b/tests/Type/WebMozartAssert/data/bug-118.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug118;
 

--- a/tests/Type/WebMozartAssert/data/bug-119.php
+++ b/tests/Type/WebMozartAssert/data/bug-119.php
@@ -1,13 +1,11 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug119;
 
 use DateTime;
 use Webmozart\Assert\Assert;
 
-function test(float $a, float $b, float $c, float $d, DateTime  $e): void
+function test(float $a, float $b, float $c, float $d, DateTime $e): void
 {
 	Assert::greaterThan($a, 0);
 	Assert::greaterThanEq($b, 0);

--- a/tests/Type/WebMozartAssert/data/bug-130.php
+++ b/tests/Type/WebMozartAssert/data/bug-130.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug130;
 
@@ -6,6 +6,7 @@ use Webmozart\Assert\Assert;
 
 class Bug130
 {
+
 	/** @var array<int, array{id: string, num_order: string}> */
 	protected $orders = [];
 
@@ -19,4 +20,5 @@ class Bug130
 
 		return $this;
 	}
+
 }

--- a/tests/Type/WebMozartAssert/data/bug-32.php
+++ b/tests/Type/WebMozartAssert/data/bug-32.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug32;
 

--- a/tests/Type/WebMozartAssert/data/bug-33.php
+++ b/tests/Type/WebMozartAssert/data/bug-33.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug33;
 

--- a/tests/Type/WebMozartAssert/data/bug-68.php
+++ b/tests/Type/WebMozartAssert/data/bug-68.php
@@ -1,12 +1,11 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug68;
 
 use Webmozart\Assert\Assert;
+use function explode;
 
-$encryptedValue = "some value";
+$encryptedValue = 'some value';
 $valueParts = explode(':', $encryptedValue);
 
 Assert::count(

--- a/tests/Type/WebMozartAssert/data/bug-8.php
+++ b/tests/Type/WebMozartAssert/data/bug-8.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertBug8;
 

--- a/tests/Type/WebMozartAssert/data/bug-85.php
+++ b/tests/Type/WebMozartAssert/data/bug-85.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\WebMozartAssert;
 

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\WebMozartAssert;
 
 use stdClass;
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
 
 class CollectionTest
 {
@@ -11,49 +12,49 @@ class CollectionTest
 	public function allString(array $a, $b): void
 	{
 		Assert::allString($a);
-		\PHPStan\Testing\assertType('array<string>', $a);
+		assertType('array<string>', $a);
 
 		Assert::allString($b);
-		\PHPStan\Testing\assertType('iterable<string>', $b);
+		assertType('iterable<string>', $b);
 	}
 
 	public function allStringNotEmpty(array $a, iterable $b, $c): void
 	{
 		Assert::allStringNotEmpty($a);
-		\PHPStan\Testing\assertType('array<non-empty-string>', $a);
+		assertType('array<non-empty-string>', $a);
 
 		Assert::allStringNotEmpty($b);
-		\PHPStan\Testing\assertType('iterable<non-empty-string>', $b);
+		assertType('iterable<non-empty-string>', $b);
 
 		Assert::allStringNotEmpty($c);
-		\PHPStan\Testing\assertType('iterable<non-empty-string>', $c);
+		assertType('iterable<non-empty-string>', $c);
 	}
 
 	public function allInteger(array $a, iterable $b, $c): void
 	{
 		Assert::allInteger($a);
-		\PHPStan\Testing\assertType('array<int>', $a);
+		assertType('array<int>', $a);
 
 		Assert::allInteger($b);
-		\PHPStan\Testing\assertType('iterable<int>', $b);
+		assertType('iterable<int>', $b);
 
 		Assert::allInteger($c);
-		\PHPStan\Testing\assertType('iterable<int>', $c);
+		assertType('iterable<int>', $c);
 	}
 
 	public function allInstanceOf(array $a, array $b, array $c, $d): void
 	{
 		Assert::allIsInstanceOf($a, stdClass::class);
-		\PHPStan\Testing\assertType('array<stdClass>', $a);
+		assertType('array<stdClass>', $a);
 
 		Assert::allIsInstanceOf($b, new stdClass());
-		\PHPStan\Testing\assertType('array<stdClass>', $b);
+		assertType('array<stdClass>', $b);
 
 		Assert::allIsInstanceOf($c, 17);
-		\PHPStan\Testing\assertType('array', $c);
+		assertType('array', $c);
 
 		Assert::allIsInstanceOf($d, new stdClass());
-		\PHPStan\Testing\assertType('iterable<stdClass>', $d);
+		assertType('iterable<stdClass>', $d);
 	}
 
 	/**
@@ -64,13 +65,13 @@ class CollectionTest
 	public function allNotInstanceOf(array $a, array $b, array $c): void
 	{
 		Assert::allNotInstanceOf($a, CollectionBar::class);
-		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $a);
+		assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $a);
 
 		Assert::allNotInstanceOf($b, new stdClass());
-		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $b);
+		assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $b);
 
 		Assert::allNotInstanceOf($c, 17);
-		\PHPStan\Testing\assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $c);
+		assertType('array<PHPStan\Type\WebMozartAssert\CollectionFoo>', $c);
 	}
 
 	/**
@@ -79,7 +80,7 @@ class CollectionTest
 	public function allNotNull(array $a): void
 	{
 		Assert::allNotNull($a);
-		\PHPStan\Testing\assertType('array<int>', $a);
+		assertType('array<int>', $a);
 	}
 
 	/**
@@ -88,19 +89,19 @@ class CollectionTest
 	public function allNotSame(array $a): void
 	{
 		Assert::allNotSame($a, -1);
-		\PHPStan\Testing\assertType('array{1, -2|2, -3|3}', $a);
+		assertType('array{1, -2|2, -3|3}', $a);
 	}
 
 	public function allSubclassOf(array $a, iterable $b, $c): void
 	{
 		Assert::allSubclassOf($a, self::class);
-		\PHPStan\Testing\assertType('array<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $a);
+		assertType('array<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $a);
 
 		Assert::allSubclassOf($b, self::class);
-		\PHPStan\Testing\assertType('iterable<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $b);
+		assertType('iterable<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $b);
 
 		Assert::allSubclassOf($c, self::class);
-		\PHPStan\Testing\assertType('iterable<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $c);
+		assertType('iterable<class-string<PHPStan\Type\WebMozartAssert\CollectionTest>|PHPStan\Type\WebMozartAssert\CollectionTest>', $c);
 	}
 
 	/**
@@ -111,13 +112,13 @@ class CollectionTest
 	public function allKeyExists(array $a, array $b, array $c, $d): void
 	{
 		Assert::allKeyExists($a, 'id');
-		\PHPStan\Testing\assertType('array<array{id: int}>', $a);
+		assertType('array<array{id: int}>', $a);
 
 		Assert::allKeyExists($b, 'id');
-		\PHPStan\Testing\assertType('array<int, array<string, mixed>&hasOffset(\'id\')>', $b);
+		assertType('array<int, array<string, mixed>&hasOffset(\'id\')>', $b);
 
 		Assert::allKeyExists($c, 'id');
-		\PHPStan\Testing\assertType('array<array&hasOffset(\'id\')>', $c);
+		assertType('array<array&hasOffset(\'id\')>', $c);
 	}
 
 	/**
@@ -126,7 +127,7 @@ class CollectionTest
 	public function allCount(array $a): void
 	{
 		Assert::allCount($a, 2);
-		\PHPStan\Testing\assertType('array<non-empty-array>', $a);
+		assertType('array<non-empty-array>', $a);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/comparison.php
+++ b/tests/Type/WebMozartAssert/data/comparison.php
@@ -1,46 +1,48 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\WebMozartAssert;
 
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
 
 class ComparisonTest
 {
+
 	public function true($a, $b): void
 	{
 		Assert::true($a);
-		\PHPStan\Testing\assertType('true', $a);
+		assertType('true', $a);
 
 		Assert::nullOrTrue($b);
-		\PHPStan\Testing\assertType('true|null', $b);
+		assertType('true|null', $b);
 	}
 
 	public function false($a, $b): void
 	{
 		Assert::false($a);
-		\PHPStan\Testing\assertType('false', $a);
+		assertType('false', $a);
 
 		Assert::nullOrFalse($b);
-		\PHPStan\Testing\assertType('false|null', $b);
+		assertType('false|null', $b);
 	}
 
 	public function notFalse($a, $b): void
 	{
 		/** @var int|false $a */
 		Assert::notFalse($a);
-		\PHPStan\Testing\assertType('int', $a);
+		assertType('int', $a);
 	}
 
 	public function null($a): void
 	{
 		Assert::null($a);
-		\PHPStan\Testing\assertType('null', $a);
+		assertType('null', $a);
 	}
 
 	public function notNull(?int $a): void
 	{
 		Assert::notNull($a);
-		\PHPStan\Testing\assertType('int', $a);
+		assertType('int', $a);
 	}
 
 	/**
@@ -49,40 +51,40 @@ class ComparisonTest
 	public function eq(?bool $a, string $b1, string $b2, $c, ?bool $d): void
 	{
 		Assert::eq($a, null);
-		\PHPStan\Testing\assertType('false|null', $a);
+		assertType('false|null', $a);
 
 		Assert::eq($b1, $b2);
-		\PHPStan\Testing\assertType('non-empty-string', $b1);
+		assertType('non-empty-string', $b1);
 
 		Assert::eq($c, false);
-		\PHPStan\Testing\assertType('0|0.0|\'\'|\'0\'|array{}|false|null', $c);
+		assertType('0|0.0|\'\'|\'0\'|array{}|false|null', $c);
 
 		Assert::nullOrEq($d, true);
-		\PHPStan\Testing\assertType('true|null', $d);
+		assertType('true|null', $d);
 	}
 
 	public function notEq(?bool $a, string $b, $c, ?bool $d): void
 	{
 		Assert::notEq($a, null);
-		\PHPStan\Testing\assertType('true', $a);
+		assertType('true', $a);
 
 		Assert::notEq($b, '');
-		\PHPStan\Testing\assertType('non-empty-string', $b);
+		assertType('non-empty-string', $b);
 
 		Assert::notEq($c, true);
-		\PHPStan\Testing\assertType('0|0.0|\'\'|\'0\'|array{}|false|null', $c);
+		assertType('0|0.0|\'\'|\'0\'|array{}|false|null', $c);
 
 		Assert::nullOrNotEq($d, true);
-		\PHPStan\Testing\assertType('false|null', $d);
+		assertType('false|null', $d);
 	}
 
 	public function same($a, $b): void
 	{
 		Assert::same($a, 1);
-		\PHPStan\Testing\assertType('1', $a);
+		assertType('1', $a);
 
 		Assert::nullOrSame($b, 1);
-		\PHPStan\Testing\assertType('1|null', $b);
+		assertType('1|null', $b);
 	}
 
 	/**
@@ -91,75 +93,76 @@ class ComparisonTest
 	public function notSame($a): void
 	{
 		Assert::notSame($a, 1);
-		\PHPStan\Testing\assertType('-1', $a);
+		assertType('-1', $a);
 	}
 
 	public function greaterThan(int $a, ?int $b): void
 	{
 		Assert::greaterThan($a, 17);
-		\PHPStan\Testing\assertType('int<18, max>', $a);
+		assertType('int<18, max>', $a);
 
 		Assert::nullOrGreaterThan($b, 17);
-		\PHPStan\Testing\assertType('int<18, max>|null', $b);
+		assertType('int<18, max>|null', $b);
 	}
 
 	public function greaterThanEq(int $a, ?int $b): void
 	{
 		Assert::greaterThanEq($a, 17);
-		\PHPStan\Testing\assertType('int<17, max>', $a);
+		assertType('int<17, max>', $a);
 
 		Assert::nullOrGreaterThanEq($b, 17);
-		\PHPStan\Testing\assertType('int<17, max>|null', $b);
+		assertType('int<17, max>|null', $b);
 	}
 
 	public function lessThan(int $a, ?int $b): void
 	{
 		Assert::lessThan($a, 17);
-		\PHPStan\Testing\assertType('int<min, 16>', $a);
+		assertType('int<min, 16>', $a);
 
 		Assert::nullOrLessThan($b, 17);
-		\PHPStan\Testing\assertType('int<min, 16>|null', $b);
+		assertType('int<min, 16>|null', $b);
 	}
 
 	public function lessThanEq(int $a, ?int $b): void
 	{
 		Assert::lessThanEq($a, 17);
-		\PHPStan\Testing\assertType('int<min, 17>', $a);
+		assertType('int<min, 17>', $a);
 
 		Assert::nullOrLessThanEq($b, 17);
-		\PHPStan\Testing\assertType('int<min, 17>|null', $b);
+		assertType('int<min, 17>|null', $b);
 	}
 
 	public function range(int $a, int $b, int $c, ?int $d): void
 	{
 		Assert::range($a, 17, 19);
-		\PHPStan\Testing\assertType('int<17, 19>', $a);
+		assertType('int<17, 19>', $a);
 
 		Assert::range($b, 19, 17);
-		\PHPStan\Testing\assertType('*NEVER*', $b);
+		assertType('*NEVER*', $b);
 
 		Assert::range($c, 17, 17);
-		\PHPStan\Testing\assertType('17', $c);
+		assertType('17', $c);
 
 		Assert::nullOrRange($d, 17, 19);
-		\PHPStan\Testing\assertType('int<17, 19>|null', $d);
+		assertType('int<17, 19>|null', $d);
 	}
 
 	public function inArray($a, $b): void
 	{
 		Assert::inArray($a, ['foo', 'bar']);
-		\PHPStan\Testing\assertType('\'bar\'|\'foo\'', $a);
+		assertType('\'bar\'|\'foo\'', $a);
 
 		Assert::nullOrInArray($b, ['foo', 'bar']);
-		\PHPStan\Testing\assertType('\'bar\'|\'foo\'|null', $b);
+		assertType('\'bar\'|\'foo\'|null', $b);
 	}
 
 	public function oneOf($a, $b): void
 	{
 		Assert::oneOf($a, [1, 2]);
-		\PHPStan\Testing\assertType('1|2', $a);
+		assertType('1|2', $a);
 
 		Assert::nullOrOneOf($b, [1, 2]);
-		\PHPStan\Testing\assertType('1|2|null', $b);
+		assertType('1|2|null', $b);
 	}
+
 }

--- a/tests/Type/WebMozartAssert/data/impossible-check-eq-not-eq.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check-eq-not-eq.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertImpossibleCheckEqNotEq;
 

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace WebmozartAssertImpossibleCheck;
 
@@ -78,7 +78,10 @@ class Foo
 
 }
 
-interface Bar {};
+interface Bar
+{
+
+}
 
 class Baz
 {

--- a/tests/Type/WebMozartAssert/data/object.php
+++ b/tests/Type/WebMozartAssert/data/object.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\WebMozartAssert;
 
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
 
 class ObjectTest
 {
@@ -10,49 +11,49 @@ class ObjectTest
 	public function classExists($a, $b): void
 	{
 		Assert::classExists($a);
-		\PHPStan\Testing\assertType('class-string', $a);
+		assertType('class-string', $a);
 
 		Assert::nullOrClassExists($b);
-		\PHPStan\Testing\assertType('class-string|null', $b);
+		assertType('class-string|null', $b);
 	}
 
 	public function subclassOf($a, $b): void
 	{
 		Assert::subclassOf($a, self::class);
-		\PHPStan\Testing\assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest', $a);
+		assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest', $a);
 
 		Assert::nullOrSubclassOf($b, self::class);
-		\PHPStan\Testing\assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest|null', $b);
+		assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectTest>|PHPStan\Type\WebMozartAssert\ObjectTest|null', $b);
 	}
 
 	public function interfaceExists($a, $b): void
 	{
 		Assert::interfaceExists($a);
-		\PHPStan\Testing\assertType('class-string', $a);
+		assertType('class-string', $a);
 
 		Assert::nullOrInterfaceExists($b);
-		\PHPStan\Testing\assertType('class-string|null', $b);
+		assertType('class-string|null', $b);
 	}
 
 	public function implementsInterface($a, $b): void
 	{
 		Assert::implementsInterface($a, ObjectFoo::class);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\ObjectFoo', $a);
+		assertType('PHPStan\Type\WebMozartAssert\ObjectFoo', $a);
 
 		Assert::nullOrImplementsInterface($b, ObjectFoo::class);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\ObjectFoo|null', $b);
+		assertType('PHPStan\Type\WebMozartAssert\ObjectFoo|null', $b);
 	}
 
 	public function propertyExists(object $a): void
 	{
 		Assert::propertyExists($a, 'foo');
-		\PHPStan\Testing\assertType('object&hasProperty(foo)', $a);
+		assertType('object&hasProperty(foo)', $a);
 	}
 
 	public function methodExists(object $a): void
 	{
 		Assert::methodExists($a, 'foo');
-		\PHPStan\Testing\assertType('object&hasMethod(foo)', $a);
+		assertType('object&hasMethod(foo)', $a);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\WebMozartAssert;
 
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
 
 class TestStrings
 {
@@ -10,67 +11,67 @@ class TestStrings
 	public function length(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::length($a, 0);
-		\PHPStan\Testing\assertType('\'\'', $a);
+		assertType('\'\'', $a);
 
 		Assert::length($b, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $b);
+		assertType('non-empty-string', $b);
 
 		Assert::nullOrLength($c, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $c);
+		assertType('non-empty-string', $c);
 
 		Assert::nullOrLength($d, 1);
-		\PHPStan\Testing\assertType('non-empty-string|null', $d);
+		assertType('non-empty-string|null', $d);
 	}
 
 	public function minLength(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::minLength($a, 0);
-		\PHPStan\Testing\assertType('string', $a);
+		assertType('string', $a);
 
 		Assert::minLength($b, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $b);
+		assertType('non-empty-string', $b);
 
 		Assert::nullOrMinLength($c, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $c);
+		assertType('non-empty-string', $c);
 
 		Assert::nullOrMinLength($d, 1);
-		\PHPStan\Testing\assertType('non-empty-string|null', $d);
+		assertType('non-empty-string|null', $d);
 	}
 
 	public function maxLength(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::maxLength($a, 0);
-		\PHPStan\Testing\assertType('\'\'', $a);
+		assertType('\'\'', $a);
 
 		Assert::maxLength($b, 1);
-		\PHPStan\Testing\assertType('string', $b);
+		assertType('string', $b);
 
 		Assert::nullOrMaxLength($c, 1);
-		\PHPStan\Testing\assertType('string', $c);
+		assertType('string', $c);
 
 		Assert::nullOrMaxLength($d, 1);
-		\PHPStan\Testing\assertType('string|null', $d);
+		assertType('string|null', $d);
 	}
 
 	public function lengthBetween(string $a, string $b, string $c, string $d, string $e, ?string $f): void
 	{
 		Assert::lengthBetween($a, 0, 0);
-		\PHPStan\Testing\assertType('\'\'', $a);
+		assertType('\'\'', $a);
 
 		Assert::lengthBetween($b, 0, 1);
-		\PHPStan\Testing\assertType('string', $b);
+		assertType('string', $b);
 
 		Assert::lengthBetween($c, 1, 0);
-		\PHPStan\Testing\assertType('*NEVER*', $c);
+		assertType('*NEVER*', $c);
 
 		Assert::lengthBetween($d, 1, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $d);
+		assertType('non-empty-string', $d);
 
 		Assert::nullOrLengthBetween($e, 1, 1);
-		\PHPStan\Testing\assertType('non-empty-string', $e);
+		assertType('non-empty-string', $e);
 
 		Assert::nullOrLengthBetween($f, 1, 1);
-		\PHPStan\Testing\assertType('non-empty-string|null', $f);
+		assertType('non-empty-string|null', $f);
 	}
 
 }

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -1,38 +1,41 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\WebMozartAssert;
 
 use DateTimeImmutable;
 use stdClass;
 use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertTyp0e;
+use function PHPStan\Testing\assertType;
 
 class TypeTest
 {
+
 	public function string($a, $b): void
 	{
 		Assert::string($a);
-		\PHPStan\Testing\assertType('string', $a);
+		assertType('string', $a);
 
 		Assert::nullOrString($b);
-		\PHPStan\Testing\assertType('string|null', $b);
+		assertType('string|null', $b);
 	}
 
 	public function stringNotEmpty($a, $b): void
 	{
 		Assert::stringNotEmpty($a);
-		\PHPStan\Testing\assertType('non-empty-string', $a);
+		assertType('non-empty-string', $a);
 
 		Assert::nullOrStringNotEmpty($b);
-		\PHPStan\Testing\assertType('non-empty-string|null', $b);
+		assertType('non-empty-string|null', $b);
 	}
 
 	public function integer($a, $b): void
 	{
 		Assert::integer($a);
-		\PHPStan\Testing\assertType('int', $a);
+		assertType('int', $a);
 
 		Assert::nullOrInteger($b);
-		\PHPStan\Testing\assertType('int|null', $b);
+		assertType('int|null', $b);
 	}
 
 	/**
@@ -41,186 +44,186 @@ class TypeTest
 	public function integerish($a, $b, int $c, float $d, string $e, string $f): void
 	{
 		Assert::integerish($a);
-		\PHPStan\Testing\assertType('float|int|numeric-string', $a);
+		assertType('float|int|numeric-string', $a);
 
 		Assert::nullOrIntegerish($b);
-		\PHPStan\Testing\assertType('float|int|numeric-string|null', $b);
+		assertType('float|int|numeric-string|null', $b);
 
 		Assert::integerish($c);
-		\PHPStan\Testing\assertType('int', $c);
+		assertType('int', $c);
 
 		Assert::integerish($d);
-		\PHPStan\Testing\assertType('float', $d);
+		assertType('float', $d);
 
 		Assert::integerish($e);
-		\PHPStan\Testing\assertType('numeric-string', $e);
+		assertType('numeric-string', $e);
 
 		Assert::integerish($f);
-		\PHPStan\Testing\assertType('numeric-string', $f);
+		assertType('numeric-string', $f);
 	}
 
 	public function positiveInteger($a, $b, $c): void
 	{
 		Assert::positiveInteger($a);
-		\PHPStan\Testing\assertType('int<1, max>', $a);
+		assertType('int<1, max>', $a);
 
 		/** @var -1 $b */
 		Assert::positiveInteger($b);
-		\PHPStan\Testing\assertType('*NEVER*', $b);
+		assertType('*NEVER*', $b);
 
 		Assert::nullOrPositiveInteger($c);
-		\PHPStan\Testing\assertType('int<1, max>|null', $c);
+		assertType('int<1, max>|null', $c);
 	}
 
 	public function float($a, $b): void
 	{
 		Assert::float($a);
-		\PHPStan\Testing\assertType('float', $a);
+		assertType('float', $a);
 
 		Assert::nullOrFloat($b);
-		\PHPStan\Testing\assertType('float|null', $b);
+		assertType('float|null', $b);
 	}
 
 	public function numeric($a, $b): void
 	{
 		Assert::numeric($a);
-		\PHPStan\Testing\assertType('float|int|numeric-string', $a);
+		assertType('float|int|numeric-string', $a);
 
 		Assert::nullOrNumeric($b);
-		\PHPStan\Testing\assertType('float|int|numeric-string|null', $b);
+		assertType('float|int|numeric-string|null', $b);
 	}
 
 	public function natural($a, $b, $c): void
 	{
 		Assert::natural($a);
-		\PHPStan\Testing\assertType('int<0, max>', $a);
+		assertType('int<0, max>', $a);
 
 		/** @var -1 $b */
 		Assert::natural($b);
-		\PHPStan\Testing\assertType('*NEVER*', $b);
+		assertType('*NEVER*', $b);
 
 		Assert::nullOrNatural($c);
-		\PHPStan\Testing\assertType('int<0, max>|null', $c);
+		assertType('int<0, max>|null', $c);
 	}
 
 	public function boolean($a, $b): void
 	{
 		Assert::boolean($a);
-		\PHPStan\Testing\assertType('bool', $a);
+		assertType('bool', $a);
 
 		Assert::nullOrBoolean($b);
-		\PHPStan\Testing\assertType('bool|null', $b);
+		assertType('bool|null', $b);
 	}
 
 	public function scalar($a, $b): void
 	{
 		Assert::scalar($a);
-		\PHPStan\Testing\assertType('bool|float|int|string', $a);
+		assertType('bool|float|int|string', $a);
 
 		Assert::nullOrScalar($b);
-		\PHPStan\Testing\assertType('bool|float|int|string|null', $b);
+		assertType('bool|float|int|string|null', $b);
 	}
 
 	public function object($a, $b): void
 	{
 		Assert::object($a);
-		\PHPStan\Testing\assertType('object', $a);
+		assertType('object', $a);
 
 		Assert::nullOrObject($b);
-		\PHPStan\Testing\assertType('object|null', $b);
+		assertType('object|null', $b);
 	}
 
 	public function resource($a, $b): void
 	{
 		Assert::resource($a);
-		\PHPStan\Testing\assertType('resource', $a);
+		assertType('resource', $a);
 
 		Assert::nullOrResource($b);
-		\PHPStan\Testing\assertType('resource|null', $b);
+		assertType('resource|null', $b);
 	}
 
 	public function isCallable($a, $b): void
 	{
 		Assert::isCallable($a);
-		\PHPStan\Testing\assertType('callable(): mixed', $a);
+		assertType('callable(): mixed', $a);
 
 		Assert::nullOrIsCallable($b);
-		\PHPStan\Testing\assertType('(callable(): mixed)|null', $b);
+		assertType('(callable(): mixed)|null', $b);
 	}
 
 	public function isArray($a, $b): void
 	{
 		Assert::isArray($a);
-		\PHPStan\Testing\assertType('array', $a);
+		assertType('array', $a);
 
 		Assert::nullOrIsArray($b);
-		\PHPStan\Testing\assertType('array|null', $b);
+		assertType('array|null', $b);
 	}
 
 	public function isTraversable($a, $b): void
 	{
 		Assert::isTraversable($a);
-		\PHPStan\Testing\assertType('array|Traversable', $a);
+		assertType('array|Traversable', $a);
 
 		Assert::nullOrIsTraversable($b);
-		\PHPStan\Testing\assertType('array|Traversable|null', $b);
+		assertType('array|Traversable|null', $b);
 	}
 
 	public function isIterable($a, $b): void
 	{
 		Assert::isIterable($a);
-		\PHPStan\Testing\assertType('array|Traversable', $a);
+		assertType('array|Traversable', $a);
 
 		Assert::nullOrIsIterable($b);
-		\PHPStan\Testing\assertType('array|Traversable|null', $b);
+		assertType('array|Traversable|null', $b);
 	}
 
 	public function isCountable($a, $b): void
 	{
 		Assert::isCountable($a);
-		\PHPStan\Testing\assertType('array|Countable', $a);
+		assertType('array|Countable', $a);
 
 		Assert::nullOrIsCountable($b);
-		\PHPStan\Testing\assertType('array|Countable|null', $b);
+		assertType('array|Countable|null', $b);
 	}
 
 	public function isInstanceOf($a, $b, $c, $d): void
 	{
 		Assert::isInstanceOf($a, self::class);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest', $a);
+		assertType('PHPStan\Type\WebMozartAssert\TypeTest', $a);
 
 		Assert::nullOrIsInstanceOf($b, self::class);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest|null', $b);
+		assertType('PHPStan\Type\WebMozartAssert\TypeTest|null', $b);
 
 		Assert::isInstanceOf($c, new stdClass());
-		\PHPStan\Testing\assertType('stdClass', $c);
+		assertType('stdClass', $c);
 
 		Assert::isInstanceOf($d, 17);
-		\PHPStan\Testing\assertType('mixed', $d);
+		assertType('mixed', $d);
 	}
 
 	public function isInstanceOfAny($a, $b, $c, $d, $e, $f, $g): void
 	{
 		Assert::isInstanceOfAny($a, [self::class, new stdClass()]);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest|stdClass', $a);
+		assertType('PHPStan\Type\WebMozartAssert\TypeTest|stdClass', $a);
 
 		Assert::isInstanceOfAny($b, [new stdClass()]);
-		\PHPStan\Testing\assertType('stdClass', $b);
+		assertType('stdClass', $b);
 
 		Assert::isInstanceOfAny($c, []);
-		\PHPStan\Testing\assertType('mixed', $c);
+		assertType('mixed', $c);
 
 		Assert::isInstanceOfAny($d, 'foo');
-		\PHPStan\Testing\assertType('mixed', $d);
+		assertType('mixed', $d);
 
 		Assert::isInstanceOfAny($e, [17]);
-		\PHPStan\Testing\assertType('mixed', $e);
+		assertType('mixed', $e);
 
 		Assert::isInstanceOfAny($f, [17, self::class]);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest', $f);
+		assertType('PHPStan\Type\WebMozartAssert\TypeTest', $f);
 
 		Assert::nullOrIsInstanceOfAny($g, [self::class, new stdClass()]);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\TypeTest|stdClass|null', $g);
+		assertType('PHPStan\Type\WebMozartAssert\TypeTest|stdClass|null', $g);
 	}
 
 	/**
@@ -231,46 +234,46 @@ class TypeTest
 	public function notInstanceOf($a, $b, $c): void
 	{
 		Assert::notInstanceOf($a, Bar::class);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Foo', $a);
+		assertType('PHPStan\Type\WebMozartAssert\Foo', $a);
 
 		Assert::notInstanceOf($b, new stdClass());
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Foo', $b);
+		assertType('PHPStan\Type\WebMozartAssert\Foo', $b);
 
 		Assert::notInstanceOf($c, 17);
-		\PHPStan\Testing\assertType('PHPStan\Type\WebMozartAssert\Bar|PHPStan\Type\WebMozartAssert\Foo', $c);
+		assertType('PHPStan\Type\WebMozartAssert\Bar|PHPStan\Type\WebMozartAssert\Foo', $c);
 	}
 
 	public function isAOf($a, $b, string $c): void
 	{
 		Assert::isAOf($a, stdClass::class);
-		\PHPStan\Testing\assertType('stdClass', $a);
+		assertType('stdClass', $a);
 
 		Assert::isAOf(Foo::class, stdClass::class);
-		\PHPStan\Testing\assertType('*NEVER*', Foo::class);
+		assertType('*NEVER*', Foo::class);
 
 		Assert::isAOf(Bar::class, stdClass::class);
-		\PHPStan\Testing\assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Bar\'', Bar::class);
+		assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Bar\'', Bar::class);
 
 		Assert::nullOrIsAOf($b, stdClass::class);
-		\PHPStan\Testing\assertType('stdClass|null', $b);
+		assertType('stdClass|null', $b);
 
 		Assert::isAOf($c, stdClass::class);
-		\PHPStan\Testing\assertType('class-string<stdClass>', $c);
+		assertType('class-string<stdClass>', $c);
 	}
 
 	public function isAnyOf($a, $b): void
 	{
 		Assert::isAnyOf($a, [DateTimeImmutable::class, stdClass::class]);
-		\PHPStan\Testing\assertTyp0e('DateTimeImmutable|stdClass', $a);
+		assertTyp0e('DateTimeImmutable|stdClass', $a);
 
 		Assert::isAnyOf($b, []);
-		\PHPStan\Testing\assertType('mixed', $b);
+		assertType('mixed', $b);
 
 		Assert::isAnyOf(Foo::class, [stdClass::class, Bar::class]);
-		\PHPStan\Testing\assertType('*NEVER*', Foo::class);
+		assertType('*NEVER*', Foo::class);
 
 		Assert::isAnyOf(Bar::class, [stdClass::class, Foo::class]);
-		\PHPStan\Testing\assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Bar\'', Bar::class);
+		assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Bar\'', Bar::class);
 	}
 
 	/**
@@ -281,31 +284,38 @@ class TypeTest
 	public function isNotA(object $a, string $b, ?object $c): void
 	{
 		Assert::isNotA($a, stdClass::class);
-		\PHPStan\Testing\assertType('DateTimeImmutable', $a);
+		assertType('DateTimeImmutable', $a);
 
 		Assert::isNotA($b, stdClass::class);
-		\PHPStan\Testing\assertType('class-string<DateTimeImmutable>', $b);
+		assertType('class-string<DateTimeImmutable>', $b);
 
 		Assert::nullOrIsNotA($c, stdClass::class);
-		\PHPStan\Testing\assertType('DateTimeImmutable|null', $c);
+		assertType('DateTimeImmutable|null', $c);
 
 		Assert::isNotA(Foo::class, stdClass::class);
-		\PHPStan\Testing\assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Foo\'', Foo::class);
+		assertType('\'PHPStan\\\Type\\\WebMozartAssert\\\Foo\'', Foo::class);
 
 		Assert::isNotA(Bar::class, stdClass::class);
-		\PHPStan\Testing\assertType('*NEVER*', Bar::class);
+		assertType('*NEVER*', Bar::class);
 	}
 
 	public function isArrayAccessible($a, $b): void
 	{
 		Assert::isArrayAccessible($a);
-		\PHPStan\Testing\assertType('array|ArrayAccess', $a);
+		assertType('array|ArrayAccess', $a);
 
 		Assert::nullOrIsArrayAccessible($b);
-		\PHPStan\Testing\assertType('array|ArrayAccess|null', $b);
+		assertType('array|ArrayAccess|null', $b);
 	}
+
 }
 
-class Foo {}
+class Foo
+{
 
-class Bar extends stdClass {}
+}
+
+class Bar extends stdClass
+{
+
+}


### PR DESCRIPTION
Wanted to do this since forever and now's a good time I think. I know CS is not enforced in those data files, but it bothered me that e.g. `assertType` was not imported but used via FQCN instead.