### PR TITLE
Support string assertions resulting in non-empty-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,26 @@ This extension specifies types of values passed to:
 * `Assert::methodExists`
 * `Assert::propertyExists`
 * `Assert::isArrayAccessible`
+* `Assert::contains`
+* `Assert::startsWith`
+* `Assert::startsWithLetter`
+* `Assert::endsWith`
+* `Assert::unicodeLetters`
+* `Assert::alpha`
+* `Assert::digits`
+* `Assert::alnum`
+* `Assert::lower`
+* `Assert::upper`
 * `Assert::length`
 * `Assert::minLength`
 * `Assert::maxLength`
 * `Assert::lengthBetween`
+* `Assert::uuid`
+* `Assert::ip`
+* `Assert::ipv4`
+* `Assert::ipv6`
+* `Assert::email`
+* `Assert::notWhitespaceOnly`
 * `nullOr*`, `all*` and `allNullOr*` variants of the above methods
 
 

--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -739,9 +739,9 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 			];
 
 			foreach (['contains', 'startsWith', 'endsWith'] as $name) {
-				self::$resolvers[$name] = static function (Scope $scope, Arg $value, Arg $subString): array {
+				self::$resolvers[$name] = static function (Scope $scope, Arg $value, Arg $subString) use ($name): array {
 					if ($scope->getType($subString->value)->isNonEmptyString()->yes()) {
-						return self::createIsNonEmptyStringAndSomethingExprPair([$value, $subString]);
+						return self::createIsNonEmptyStringAndSomethingExprPair($name, [$value, $subString]);
 					}
 
 					return [self::$resolvers['string']($scope, $value), null];
@@ -764,8 +764,8 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				'notWhitespaceOnly',
 			];
 			foreach ($assertionsResultingAtLeastInNonEmptyString as $name) {
-				self::$resolvers[$name] = static function (Scope $scope, Arg $value): array {
-					return self::createIsNonEmptyStringAndSomethingExprPair([$value]);
+				self::$resolvers[$name] = static function (Scope $scope, Arg $value) use ($name): array {
+					return self::createIsNonEmptyStringAndSomethingExprPair($name, [$value]);
 				};
 			}
 
@@ -956,7 +956,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 	 * @param Arg[] $args
 	 * @return array{Expr, Expr}
 	 */
-	private static function createIsNonEmptyStringAndSomethingExprPair(array $args): array
+	private static function createIsNonEmptyStringAndSomethingExprPair(string $name, array $args): array
 	{
 		$expr = new BooleanAnd(
 			new FuncCall(
@@ -971,7 +971,7 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 
 		$rootExpr = new BooleanAnd(
 			$expr,
-			new FuncCall(new Name('FAUX_FUNCTION'), $args)
+			new FuncCall(new Name('FAUX_FUNCTION_ ' . $name), $args)
 		);
 
 		return [$expr, $rootExpr];

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -68,6 +68,22 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::allCount() with array<non-empty-array> and 2 will always evaluate to true.',
 				76,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::uuid() with non-empty-string will always evaluate to true.',
+				84,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::contains() with non-empty-string and \'foo\' will always evaluate to true.',
+				88,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::allUuid() with array<non-empty-string> will always evaluate to true.',
+				94,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::allContains() with array<non-empty-string> and \'foo\' will always evaluate to true.',
+				98,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -30,6 +30,30 @@ class CollectionTest
 		assertType('iterable<non-empty-string>', $c);
 	}
 
+	public function allContains(array $a, iterable $b, $c): void
+	{
+		Assert::allContains($a, 'foo');
+		assertType('array<non-empty-string>', $a);
+
+		Assert::allContains($b, 'foo');
+		assertType('iterable<non-empty-string>', $b);
+
+		Assert::allContains($c, 'foo');
+		assertType('iterable<non-empty-string>', $c);
+	}
+
+	public function allNullOrContains(array $a, iterable $b, $c): void
+	{
+		Assert::allNullOrContains($a, 'foo');
+		assertType('array<non-empty-string|null>', $a);
+
+		Assert::allNullOrContains($b, 'foo');
+		assertType('iterable<non-empty-string|null>', $b);
+
+		Assert::allNullOrContains($c, 'foo');
+		assertType('iterable<non-empty-string|null>', $c);
+	}
+
 	public function allInteger(array $a, iterable $b, $c): void
 	{
 		Assert::allInteger($a);

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -76,6 +76,29 @@ class Foo
 		Assert::allCount($a, 2);
 	}
 
+	public function nonEmptyStringAndSomethingUnknownNarrow($a, string $b, array $c, array $d): void
+	{
+		Assert::string($a);
+		Assert::stringNotEmpty($a);
+		Assert::uuid($a);
+		Assert::uuid($a); // only this should report
+
+		Assert::stringNotEmpty($b);
+		Assert::contains($b, 'foo');
+		Assert::contains($b, 'foo'); // only this should report
+		Assert::contains($b, 'bar');
+
+		Assert::allString($c);
+		Assert::allStringNotEmpty($c);
+		Assert::allUuid($c);
+		Assert::allUuid($c); // only this should report
+
+		Assert::allStringNotEmpty($d);
+		Assert::allContains($d, 'foo');
+		Assert::allContains($d, 'foo'); // only this should report
+		Assert::allContains($d, 'bar');
+	}
+
 }
 
 interface Bar {};

--- a/tests/Type/WebMozartAssert/data/string.php
+++ b/tests/Type/WebMozartAssert/data/string.php
@@ -8,6 +8,84 @@ use function PHPStan\Testing\assertType;
 class TestStrings
 {
 
+	/**
+	 * @param non-empty-string $b
+	 */
+	public function contains(string $a, string $b): void
+	{
+		Assert::contains($a, $a);
+		assertType('string', $a);
+
+		Assert::contains($a, $b);
+		assertType('non-empty-string', $a);
+	}
+
+	/**
+	 * @param non-empty-string $b
+	 */
+	public function startsWith(string $a, string $b): void
+	{
+		Assert::startsWith($a, $a);
+		assertType('string', $a);
+
+		Assert::startsWith($a, $b);
+		assertType('non-empty-string', $a);
+	}
+
+	public function startsWithLetter(string $a): void
+	{
+		Assert::startsWithLetter($a);
+		assertType('non-empty-string', $a);
+	}
+
+	/**
+	 * @param non-empty-string $b
+	 */
+	public function endsWith(string $a, string $b): void
+	{
+		Assert::endsWith($a, $a);
+		assertType('string', $a);
+
+		Assert::endsWith($a, $b);
+		assertType('non-empty-string', $a);
+	}
+
+	public function unicodeLetters($a): void
+	{
+		Assert::unicodeLetters($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function alpha($a): void
+	{
+		Assert::alpha($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function digits(string $a): void
+	{
+		Assert::digits($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function alnum(string $a): void
+	{
+		Assert::alnum($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function lower(string $a): void
+	{
+		Assert::lower($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function upper(string $a): void
+	{
+		Assert::upper($a);
+		assertType('non-empty-string', $a);
+	}
+
 	public function length(string $a, string $b, string $c, ?string $d): void
 	{
 		Assert::length($a, 0);
@@ -72,6 +150,42 @@ class TestStrings
 
 		Assert::nullOrLengthBetween($f, 1, 1);
 		assertType('non-empty-string|null', $f);
+	}
+
+	public function uuid(string $a): void
+	{
+		Assert::uuid($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function ip($a): void
+	{
+		Assert::ip($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function ipv4($a): void
+	{
+		Assert::ipv4($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function ipv6($a): void
+	{
+		Assert::ipv6($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function email($a): void
+	{
+		Assert::email($a);
+		assertType('non-empty-string', $a);
+	}
+
+	public function notWhitespaceOnly(string $a): void
+	{
+		Assert::notWhitespaceOnly($a);
+		assertType('non-empty-string', $a);
 	}
 
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/129

Brings back what was reverted in https://github.com/phpstan/phpstan-webmozart-assert/pull/89 and steals ideas from https://github.com/phpstan/phpstan-webmozart-assert/pull/128