### PR TITLE
Add FQCN support to `implementsInterface`

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -451,10 +451,16 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						return null;
 					}
 
-					return new Instanceof_(
-						$expr->value,
-						new Name($classType->getValue())
-					);
+					$classReflection = (new ObjectType($classType->getValue()))->getClassReflection();
+					if ($classReflection === null) {
+						return null;
+					}
+
+					if (!$classReflection->isInterface()) {
+						return new ConstFetch(new Name('false'));
+					}
+
+					return self::$resolvers['subclassOf']($scope, $expr, $class);
 				},
 				'keyExists' => static function (Scope $scope, Arg $array, Arg $key): Expr {
 					return new FuncCall(

--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -18,6 +18,8 @@ class AssertTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/object.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/string.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/type.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-18.php');
 	}
 
 	/**

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -84,6 +84,18 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::allContains() with array<non-empty-string> and \'foo\' will always evaluate to true.',
 				98,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::implementsInterface() with class-string<WebmozartAssertImpossibleCheck\Bar>|WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
+				105,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::implementsInterface() with class-string<WebmozartAssertImpossibleCheck\Bar> and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
+				108,
+			],
+			[
+				'Call to static method Webmozart\Assert\Assert::implementsInterface() with mixed and \'WebmozartAssertImpossibleCheck\\\Foo\' will always evaluate to false.',
+				111,
+			],
 		]);
 	}
 
@@ -173,6 +185,21 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				17,
 			],
 		]);
+	}
+
+	public function testBug17(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-17.php'], [
+			[
+				'Call to static method Webmozart\Assert\Assert::implementsInterface() with \'DateTime\' and \'DateTimeInterface\' will always evaluate to true.',
+				9,
+			],
+		]);
+	}
+
+	public function testBug18(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-18.php'], []);
 	}
 
 	public function testBug32(): void

--- a/tests/Type/WebMozartAssert/data/bug-17.php
+++ b/tests/Type/WebMozartAssert/data/bug-17.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Bug17;
+
+use DateTimeInterface;
+use Webmozart\Assert\Assert;
+
+(function () {
+	Assert::implementsInterface(\DateTime::class, DateTimeInterface::class);
+	Assert::implementsInterface(\DateTimeZone::class, DateTimeInterface::class);
+})();

--- a/tests/Type/WebMozartAssert/data/bug-18.php
+++ b/tests/Type/WebMozartAssert/data/bug-18.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Bug18;
+
+use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
+
+class MyThingFactory
+{
+	public function make(string $thing)
+	{
+		Assert::implementsInterface($thing, SomeDto::class);
+
+		assertType('class-string<Bug18\SomeDto>', $thing);
+	}
+}
+
+interface SomeDto {}

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -99,6 +99,18 @@ class Foo
 		Assert::allContains($d, 'bar');
 	}
 
+	public function implementsInterface($a, string $b, $c): void
+	{
+		Assert::implementsInterface($a, Bar::class);
+		Assert::implementsInterface($a, Bar::class);
+
+		Assert::implementsInterface($b, Bar::class);
+		Assert::implementsInterface($b, Bar::class);
+
+		Assert::implementsInterface($c, Unknown::class);
+		Assert::implementsInterface($c, self::class);
+	}
+
 }
 
 interface Bar {};

--- a/tests/Type/WebMozartAssert/data/object.php
+++ b/tests/Type/WebMozartAssert/data/object.php
@@ -35,13 +35,25 @@ class ObjectTest
 		assertType('class-string|null', $b);
 	}
 
-	public function implementsInterface($a, $b): void
+	public function implementsInterface($a, $b, string $c, object $d, $e, $f): void
 	{
 		Assert::implementsInterface($a, ObjectFoo::class);
-		assertType('PHPStan\Type\WebMozartAssert\ObjectFoo', $a);
+		assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectFoo>|PHPStan\Type\WebMozartAssert\ObjectFoo', $a);
 
 		Assert::nullOrImplementsInterface($b, ObjectFoo::class);
-		assertType('PHPStan\Type\WebMozartAssert\ObjectFoo|null', $b);
+		assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectFoo>|PHPStan\Type\WebMozartAssert\ObjectFoo|null', $b);
+
+		Assert::implementsInterface($c, ObjectFoo::class);
+		assertType('class-string<PHPStan\Type\WebMozartAssert\ObjectFoo>', $c);
+
+		Assert::implementsInterface($d, ObjectFoo::class);
+		assertType('PHPStan\Type\WebMozartAssert\ObjectFoo', $d);
+
+		Assert::implementsInterface($e, self::class);
+		assertType('mixed', $e);
+
+		Assert::implementsInterface($f, Unknown::class);
+		assertType('mixed', $f);
 	}
 
 	public function propertyExists(object $a): void


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/17
Closes https://github.com/phpstan/phpstan-webmozart-assert/issues/18

The idea behind this is amazingly simple. If the `$class` arg is a known interface we can simply use `is_subclass_of` to check if the given object or FQCN implements that interface.