### PR TITLE
Specify non-empty-array for Assert::uniqueValues

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -752,6 +752,9 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						)
 					);
 				},
+				'uniqueValues' => static function (Scope $scope, Arg $value): array {
+					return self::createIsNonEmptyArrayAndSomethingExprPair('uniqueValues', [$value]);
+				},
 			];
 
 			foreach (['contains', 'startsWith', 'endsWith'] as $name) {
@@ -784,7 +787,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 					return self::createIsNonEmptyStringAndSomethingExprPair($name, [$value]);
 				};
 			}
-
 		}
 
 		return $this->resolvers;
@@ -993,6 +995,28 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				$args[0]->value,
 				new String_('')
 			)
+		);
+
+		$rootExpr = new BooleanAnd(
+			$expr,
+			new FuncCall(new Name('FAUX_FUNCTION_ ' . $name), $args)
+		);
+
+		return [$expr, $rootExpr];
+	}
+
+	/**
+	 * @param Arg[] $args
+	 * @return array{Expr, Expr}
+	 */
+	private static function createIsNonEmptyArrayAndSomethingExprPair(string $name, array $args): array
+	{
+		$expr = new GreaterOrEqual(
+			new FuncCall(
+				new Name('count'),
+				[$args[0]]
+			),
+			new LNumber(1)
 		);
 
 		$rootExpr = new BooleanAnd(

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -305,6 +305,12 @@ class TypeTest
 		Assert::nullOrIsArrayAccessible($b);
 		assertType('array|ArrayAccess|null', $b);
 	}
+
+	public function uniqueValues(array $a): void
+	{
+		Assert::uniqueValues($a);
+		assertType('non-empty-array', $a);
+	}
 }
 
 class Foo {}


### PR DESCRIPTION
This was basically the only simple thing still missing. Implemented the same way as the `non-empty-string` + something (e.g. Assert::email) were implemented. 

See https://github.com/webmozarts/assert?tab=readme-ov-file#type-assertions
> Check that the given array contains unique values