### PR TITLE
Revert non-empty-array specification for Assert::uniqueValues

### DIFF
--- a/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
+++ b/src/Type/WebMozartAssert/AssertTypeSpecifyingExtension.php
@@ -752,9 +752,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 						)
 					);
 				},
-				'uniqueValues' => static function (Scope $scope, Arg $value): array {
-					return self::createIsNonEmptyArrayAndSomethingExprPair('uniqueValues', [$value]);
-				},
 			];
 
 			foreach (['contains', 'startsWith', 'endsWith'] as $name) {
@@ -995,28 +992,6 @@ class AssertTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtensi
 				$args[0]->value,
 				new String_('')
 			)
-		);
-
-		$rootExpr = new BooleanAnd(
-			$expr,
-			new FuncCall(new Name('FAUX_FUNCTION_ ' . $name), $args)
-		);
-
-		return [$expr, $rootExpr];
-	}
-
-	/**
-	 * @param Arg[] $args
-	 * @return array{Expr, Expr}
-	 */
-	private static function createIsNonEmptyArrayAndSomethingExprPair(string $name, array $args): array
-	{
-		$expr = new GreaterOrEqual(
-			new FuncCall(
-				new Name('count'),
-				[$args[0]]
-			),
-			new LNumber(1)
 		);
 
 		$rootExpr = new BooleanAnd(

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -305,12 +305,6 @@ class TypeTest
 		Assert::nullOrIsArrayAccessible($b);
 		assertType('array|ArrayAccess|null', $b);
 	}
-
-	public function uniqueValues(array $a): void
-	{
-		Assert::uniqueValues($a);
-		assertType('non-empty-array', $a);
-	}
 }
 
 class Foo {}


### PR DESCRIPTION
Reverts https://github.com/phpstan/phpstan-webmozart-assert/pull/177

See https://github.com/phpstan/phpstan-webmozart-assert/pull/177#issuecomment-2027775826 (thx @VincentLanglet !)

Also
```php
➜  phpstan-webmozart-assert git:(1.2.x) cat test.php 
<?php declare(strict_types = 1);

require_once __DIR__ . '/vendor/autoload.php';

\Webmozart\Assert\Assert::uniqueValues([]);
echo "still here";
➜  phpstan-webmozart-assert git:(1.2.x) ✗ php test.php 
still here%  
```

sorry for missing that