### PR TITLE
Allow to `Assert::isInstanceOf()` to work with generic and anonymous class strings

### DIFF
--- a/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
+++ b/tests/Type/WebMozartAssert/AssertTypeSpecifyingExtensionTest.php
@@ -22,6 +22,7 @@ class AssertTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-18.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-117.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-150.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-183.php');
 	}
 
 	/**

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -101,6 +101,10 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::implementsInterface() with mixed and \'WebmozartAssertImpossibleCheck\\\Foo\' will always evaluate to false.',
 				111,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::isInstanceOf() with Exception and class-string<Exception> will always evaluate to true.',
+				119,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/data/bug-183.php
+++ b/tests/Type/WebMozartAssert/data/bug-183.php
@@ -1,0 +1,62 @@
+<?php
+
+use Webmozart\Assert\Assert;
+use function PHPStan\Testing\assertType;
+
+function assertInstanceOfWithString($value, string $className): void
+{
+	Assert::isInstanceOf($value, $className);
+	assertType('object', $value);
+}
+
+/**
+ * @param class-string $className
+ */
+function assertInstanceOfWithClassString($value, string $className): void
+{
+	Assert::isInstanceOf($value, $className);
+	assertType('object', $value);
+}
+
+/**
+ * @param class-string<\Bug183> $className
+ */
+function assertInstanceOfWithGenericClassString($value, string $className): void
+{
+	Assert::isInstanceOf($value, $className);
+	assertType('Bug183', $value);
+}
+
+/**
+ * @param class-string<\Bug183Bar<\Bug183>> $className
+ */
+function assertInstanceOfWithGenericClassStringReferencingGenericClass($value, string $className): void
+{
+	Assert::isInstanceOf($value, $className);
+	assertType('Bug183Bar', $value);
+}
+
+/**
+ * @param class-string<\Bug183|\Bug183Foo> $className
+ */
+function assertInstanceOfWithGenericUnionClassString($value, string $className): void
+{
+	Assert::isInstanceOf($value, $className);
+	assertType('Bug183|Bug183Foo', $value);
+}
+
+
+interface Bug183
+{
+}
+
+interface Bug183Foo
+{
+}
+
+/**
+ * @template T of object
+ */
+interface Bug183Bar
+{
+}

--- a/tests/Type/WebMozartAssert/data/collection.php
+++ b/tests/Type/WebMozartAssert/data/collection.php
@@ -75,7 +75,7 @@ class CollectionTest
 		assertType('array<stdClass>', $b);
 
 		Assert::allIsInstanceOf($c, 17);
-		assertType('array', $c);
+		assertType('array<object>', $c);
 
 		Assert::allIsInstanceOf($d, new stdClass());
 		assertType('iterable<stdClass>', $d);

--- a/tests/Type/WebMozartAssert/data/type.php
+++ b/tests/Type/WebMozartAssert/data/type.php
@@ -197,7 +197,7 @@ class TypeTest
 		assertType('stdClass', $c);
 
 		Assert::isInstanceOf($d, 17);
-		assertType('mixed', $d);
+		assertType('object', $d);
 	}
 
 	public function isInstanceOfAny($a, $b, $c, $d, $e, $f, $g): void
@@ -215,10 +215,10 @@ class TypeTest
 		assertType('mixed', $d);
 
 		Assert::isInstanceOfAny($e, [17]);
-		assertType('mixed', $e);
+		assertType('object', $e);
 
 		Assert::isInstanceOfAny($f, [17, self::class]);
-		assertType('PHPStan\Type\WebMozartAssert\TypeTest', $f);
+		assertType('object', $f);
 
 		Assert::nullOrIsInstanceOfAny($g, [self::class, new stdClass()]);
 		assertType('PHPStan\Type\WebMozartAssert\TypeTest|stdClass|null', $g);


### PR DESCRIPTION
This should fix #183 by adding extra checks for class strings to the type resolvers for `Assert::isInstanceOf()`. Before this PR the extension would do nothing if it couldn't find a constant class name, now it will always narrow to at least `object`