### PR TITLE
Update webmozart/assert to 2.0 & changed minimum PHP version to 8.2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
@@ -88,9 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
@@ -127,9 +121,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"MIT"
 	],
 	"require": {
-		"php": "^7.4 || ^8.0",
+		"php": "^8.2",
 		"phpstan/phpstan": "^2.1.7"
 	},
 	"require-dev": {
@@ -16,11 +16,11 @@
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^9.6",
-		"webmozart/assert": "^1.11.0"
+		"webmozart/assert": "^2.0"
 	},
 	"config": {
 		"platform": {
-			"php": "7.4.6"
+			"php": "8.2.30"
 		},
 		"sort-packages": true
 	},


### PR DESCRIPTION
This PR is targeted to the 2.0.x branch but a 3.0.x branch should be created where this should be targeted to.

webmozart/assert has been updated to version 2.0 and includes some breaking changes, for example updating the minimum required PHP version to 8.2