### PR TITLE
Update webmozart/assert version constraint to test also ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^9.6",
-		"webmozart/assert": "^1.11.0"
+		"webmozart/assert": "^1.11.0 || ^2.0"
 	},
 	"config": {
 		"platform": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"nikic/php-parser": "^5.1",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpstan-deprecation-rules": "^2.0",
-		"phpstan/phpstan-phpunit": "^2.0",
+		"phpstan/phpstan-phpunit": "^2.0.10",
 		"phpstan/phpstan-strict-rules": "^2.0",
 		"phpunit/phpunit": "^9.6",
 		"webmozart/assert": "^1.11.0 || ^2.0"


### PR DESCRIPTION
There was a new major release of https://github.com/webmozarts/assert. Maybe @shadowhand has more insights if something need to be changed in the phpstan extension.