### PR TITLE
Fix Ci after PR Phpstan#4472

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	"keywords": ["static analysis"],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.1.7"
+		"phpstan/phpstan": "^2.1.41"
 	},
 	"require-dev": {
 		"nikic/php-parser": "^5.1",

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -116,6 +116,11 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::startsWith() with \'value\' and string will always evaluate to true.',
 				126,
 			],
+			[
+				'Call to static method Webmozart\Assert\Assert::implementsInterface() with \'WebmozartAssertImpossibleCheck\\\\Bar\' and \'WebmozartAssertImpossibleCheck\\\\Bar\' will always evaluate to false.',
+				134,
+				$tipText,
+			],
 		]);
 	}
 

--- a/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/Type/WebMozartAssert/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -91,6 +91,7 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to static method Webmozart\Assert\Assert::allContains() with array<non-empty-string> and \'foo\' will always evaluate to true.',
 				98,
 			],
+			/*
 			[
 				'Call to static method Webmozart\Assert\Assert::implementsInterface() with class-string<WebmozartAssertImpossibleCheck\Bar>|WebmozartAssertImpossibleCheck\Bar and \'WebmozartAssertImpossibleCheck\\\Bar\' will always evaluate to true.',
 				105,
@@ -101,6 +102,7 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				108,
 				$tipText,
 			],
+			*/
 			[
 				'Call to static method Webmozart\Assert\Assert::implementsInterface() with mixed and \'WebmozartAssertImpossibleCheck\\\Foo\' will always evaluate to false.',
 				111,

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -102,10 +102,10 @@ class Foo
 	public function implementsInterface($a, string $b, $c): void
 	{
 		Assert::implementsInterface($a, Bar::class);
-		Assert::implementsInterface($a, Bar::class);
+		Assert::implementsInterface($a, Bar::class); // Could be reported as always true
 
 		Assert::implementsInterface($b, Bar::class);
-		Assert::implementsInterface($b, Bar::class);
+		Assert::implementsInterface($b, Bar::class); // Could be reported as always true
 
 		Assert::implementsInterface($c, Unknown::class);
 		Assert::implementsInterface($c, self::class);

--- a/tests/Type/WebMozartAssert/data/impossible-check.php
+++ b/tests/Type/WebMozartAssert/data/impossible-check.php
@@ -127,6 +127,13 @@ class Foo
 		Assert::startsWith("value", "bix");
 	}
 
+	/** @param class-string<Bar> $a */
+	public function implementsInterface2(string $a): void
+	{
+		Assert::implementsInterface($a, Bar::class);
+		Assert::implementsInterface(Bar::class, Bar::class);
+	}
+
 }
 
 interface Bar {};


### PR DESCRIPTION
The only way I have so far to fix the ci after https://github.com/phpstan/phpstan-src/pull/4472

PHPStan is not good enough yet to find those "always true" checks without producing false positive and I think it's better to avoid the false positive first.

This only show that the PR on phpstan side avoid the false positive always true reported in the PR https://github.com/phpstan/phpstan-webmozart-assert/pull/194

Closes https://github.com/phpstan/phpstan-webmozart-assert/pull/194